### PR TITLE
Fix error when lambdas return symbols

### DIFF
--- a/tests/functional-testing/scheme/lambda-tail-calls/README.md
+++ b/tests/functional-testing/scheme/lambda-tail-calls/README.md
@@ -1,0 +1,37 @@
+# Lambda Return Value Corruption Bug Tests
+
+This directory contains tests for the lambda return value corruption bug fixed in commit 143d9847.
+
+## The Bug
+
+Lambda frames were overwriting `argv[0]` with their return values, corrupting the lambda form. When lambdas returned symbols, the VM would attempt to look up those data symbols as procedure names, causing crashes with `VM_ERROR_BYTECODE`. Other return types caused silent corruption.
+
+## Test Files
+
+**test-lambda-returns.scm**
+- Tests lambdas returning different types: integers, strings, booleans, quoted numbers, and symbols
+- Validates that non-recursive lambda return values don't corrupt the frame
+- All tests should pass without crashes
+
+**test-inline-vs-named.scm**
+- Tests both inline lambda calls `((lambda () 'symbol))` and named lambda calls
+- Validates that both code paths correctly handle lambda return values
+- Both should successfully return and display symbols without crashing
+
+**test-mutual-recursion.scm**
+- Tests mutual recursion with tail call optimization
+- Includes is-even?/is-odd? functions calling each other
+- Tests with small numbers for correctness and large numbers (1000) to verify TCO
+- Also tests mutual recursion with accumulator parameters
+
+## Running the Tests
+
+From the repository root:
+
+```bash
+bin/vm tests/functional-testing/scheme/lambda-tail-calls/test-lambda-returns.vm
+bin/vm tests/functional-testing/scheme/lambda-tail-calls/test-inline-vs-named.vm
+bin/vm tests/functional-testing/scheme/lambda-tail-calls/test-mutual-recursion.vm
+```
+
+All tests should complete successfully without errors.

--- a/tests/functional-testing/scheme/lambda-tail-calls/test-inline-vs-named.scm
+++ b/tests/functional-testing/scheme/lambda-tail-calls/test-inline-vs-named.scm
@@ -1,0 +1,16 @@
+;; Test inline vs named lambda calls
+
+(display "Test 1: Inline lambda returning symbol")
+(newline)
+(display ((lambda () 'inline-symbol)))
+(newline)
+(newline)
+
+(display "Test 2: Named lambda returning symbol")
+(newline)
+(define named-lambda (lambda () 'named-symbol))
+(display (named-lambda))
+(newline)
+
+(display "Done")
+(newline)

--- a/tests/functional-testing/scheme/lambda-tail-calls/test-lambda-returns.scm
+++ b/tests/functional-testing/scheme/lambda-tail-calls/test-lambda-returns.scm
@@ -1,0 +1,38 @@
+;; Test what lambdas can return
+
+(display "Test 1: Lambda returns integer")
+(newline)
+(define test1 (lambda () 42))
+(display (test1))
+(newline)
+(newline)
+
+(display "Test 2: Lambda returns string")
+(newline)
+(define test2 (lambda () "hello"))
+(display (test2))
+(newline)
+(newline)
+
+(display "Test 3: Lambda returns boolean")
+(newline)
+(define test3 (lambda () #t))
+(display (test3))
+(newline)
+(newline)
+
+(display "Test 4: Lambda returns quoted number")
+(newline)
+(define test4 (lambda () '42))
+(display (test4))
+(newline)
+(newline)
+
+(display "Test 5: Lambda returns quoted symbol")
+(newline)
+(define test5 (lambda () 'done))
+(display (test5))
+(newline)
+
+(display "Completed!")
+(newline)

--- a/tests/functional-testing/scheme/lambda-tail-calls/test-mutual-recursion.scm
+++ b/tests/functional-testing/scheme/lambda-tail-calls/test-mutual-recursion.scm
@@ -1,0 +1,73 @@
+;; Test mutual recursion with tail calls
+;; Tests whether tail call optimization works correctly
+;; when two functions call each other in tail position
+
+(display "Testing mutual recursion...")
+(newline)
+
+;; Test 1: Simple mutual recursion with booleans
+(display "Test 1: is-even? and is-odd? with small numbers")
+(newline)
+
+(define is-even?
+  (lambda (n)
+    (if (= n 0)
+        #t
+        (is-odd? (- n 1)))))
+
+(define is-odd?
+  (lambda (n)
+    (if (= n 0)
+        #f
+        (is-even? (- n 1)))))
+
+(display "is-even? 4: ")
+(display (is-even? 4))
+(newline)
+
+(display "is-odd? 4: ")
+(display (is-odd? 4))
+(newline)
+
+(display "is-even? 7: ")
+(display (is-even? 7))
+(newline)
+
+(display "is-odd? 7: ")
+(display (is-odd? 7))
+(newline)
+
+;; Test 2: Mutual recursion with larger numbers (tests TCO)
+(display "Test 2: Large numbers requiring TCO")
+(newline)
+
+(display "is-even? 1000: ")
+(display (is-even? 1000))
+(newline)
+
+(display "is-odd? 999: ")
+(display (is-odd? 999))
+(newline)
+
+;; Test 3: Mutual recursion with accumulator
+(display "Test 3: Mutual recursion with accumulator")
+(newline)
+
+(define count-a
+  (lambda (n acc)
+    (if (= n 0)
+        acc
+        (count-b (- n 1) (+ acc 1)))))
+
+(define count-b
+  (lambda (n acc)
+    (if (= n 0)
+        acc
+        (count-a (- n 1) (+ acc 1)))))
+
+(display "count-a 100 0: ")
+(display (count-a 100 0))
+(newline)
+
+(display "All mutual recursion tests completed!")
+(newline)


### PR DESCRIPTION
Lambdas returning symbol values (like 'DONE or 'SUCCESS) were causing crashes with VM_ERROR_BYTECODE. The VM was attempting to evaluate the returned symbol as a procedure name, which failed.

This fix distinguishes between intermediate tail-recursive calls (which need evaluation to continue recursion) and final return values (which should not be re-evaluated). This preserves tail call optimization while preventing the error.