### PR TITLE
Accept textual IP addresses in make-client

### DIFF
--- a/core/expr-ip.c
+++ b/core/expr-ip.c
@@ -90,15 +90,42 @@ VM_FUNCTION(make_client)
   }
 
   if(argv[1].type == VM_TYPE_STRING) {
-    status = vm_native_resolve(thread, argv[1].value.string->str);
-    if(status > 0) {
-      addr = thread->result.value.vector;
-    } else if(status == 0) {
+    uint8_t bytes[16];
+    size_t addr_len;
+    const char *addr_str = vm_string_resolve(thread, argv[1].value.string);
+
+    if(addr_str == NULL) {
+      vm_signal_error(thread, VM_ERROR_ARGUMENT_VALUE);
       return;
-    } else if(status < 0) {
-      vm_signal_error(thread, VM_ERROR_SOCKET);
-      vm_set_error_string(thread, "unable to resolve hostname");
-      return;
+    }
+
+    if(vm_native_parse_address(addr_str, bytes, &addr_len)) {
+      size_t i;
+      vm_vector_t *vector;
+
+      vector = vm_vector_create(&thread->result, addr_len,
+                                VM_VECTOR_FLAG_REGULAR);
+      if(vector == NULL) {
+        vm_signal_error(thread, VM_ERROR_HEAP);
+        return;
+      }
+      for(i = 0; i < addr_len; i++) {
+        vector->elements[i].type = VM_TYPE_INTEGER;
+        vector->elements[i].value.integer = bytes[i];
+      }
+      addr = vector;
+    } else {
+      status = vm_native_resolve(thread, (char *)addr_str);
+      if(status > 0) {
+        addr = thread->result.value.vector;
+      } else if(status == 0) {
+        return;
+      } else {
+        vm_signal_error(thread, VM_ERROR_SOCKET);
+        vm_set_error_string(thread,
+                            "unable to parse address or resolve hostname");
+        return;
+      }
     }
   } else {
     addr = argv[1].value.vector;

--- a/include/vm-native.h
+++ b/include/vm-native.h
@@ -50,6 +50,7 @@ int vm_native_get_peer_name(vm_thread_t *, vm_port_t *, vm_obj_t *);
 void vm_native_accept_client(vm_thread_t *, vm_port_t *, vm_obj_t *);
 void vm_native_incoming_clientp(vm_thread_t *, vm_port_t *, vm_obj_t *);
 int vm_native_resolve(vm_thread_t *, const char *hostname);
+int vm_native_parse_address(const char *str, uint8_t *bytes, size_t *len);
 vm_port_t *vm_native_open_file(vm_thread_t *, const char *, int);
 int vm_native_read(vm_port_t *, vm_obj_t *);
 int vm_native_read_char(vm_port_t *, vm_character_t *);

--- a/ports/contiki-ng/vm-native.c
+++ b/ports/contiki-ng/vm-native.c
@@ -39,6 +39,7 @@
 #include "lib/memb.h"
 #include "lib/sensors.h"
 #include "net/ipv6/uip.h"
+#include "net/ipv6/uiplib.h"
 #include "net/ipv6/udp-socket.h"
 #include "net/ipv6/uip-nameserver.h"
 #include "net/ipv6/uip-ds6.h"
@@ -521,6 +522,19 @@ vm_native_resolve(vm_thread_t *thread, const char *hostname)
     VM_CLEAR_FLAG(thread->expr->flags, VM_EXPR_RESTART);
     return -1;
   }
+}
+
+int
+vm_native_parse_address(const char *str, uint8_t *bytes, size_t *len)
+{
+  uip_ipaddr_t addr;
+
+  if(uiplib_ipaddrconv(str, &addr) != 0) {
+    memcpy(bytes, addr.u8, sizeof(addr.u8));
+    *len = sizeof(addr.u8);
+    return 1;
+  }
+  return 0;
 }
 
 vm_port_t *

--- a/ports/javascript/vm-native.c
+++ b/ports/javascript/vm-native.c
@@ -717,6 +717,25 @@ vm_native_resolve(vm_thread_t *thread, const char *hostname)
   return -1;
 }
 
+int
+vm_native_parse_address(const char *str, uint8_t *bytes, size_t *len)
+{
+  struct in6_addr addr6;
+  struct in_addr addr4;
+
+  if(inet_pton(AF_INET6, str, &addr6) == 1) {
+    memcpy(bytes, &addr6, sizeof(addr6));
+    *len = sizeof(addr6);
+    return 1;
+  }
+  if(inet_pton(AF_INET, str, &addr4) == 1) {
+    memcpy(bytes, &addr4, sizeof(addr4));
+    *len = sizeof(addr4);
+    return 1;
+  }
+  return 0;
+}
+
 vm_port_t *
 vm_native_open_file(vm_thread_t *thread, const char *filename, int direction)
 {

--- a/ports/posix/vm-native.c
+++ b/ports/posix/vm-native.c
@@ -723,6 +723,25 @@ vm_native_resolve(vm_thread_t *thread, const char *hostname)
   return -1;
 }
 
+int
+vm_native_parse_address(const char *str, uint8_t *bytes, size_t *len)
+{
+  struct in6_addr addr6;
+  struct in_addr addr4;
+
+  if(inet_pton(AF_INET6, str, &addr6) == 1) {
+    memcpy(bytes, &addr6, sizeof(addr6));
+    *len = sizeof(addr6);
+    return 1;
+  }
+  if(inet_pton(AF_INET, str, &addr4) == 1) {
+    memcpy(bytes, &addr4, sizeof(addr4));
+    *len = sizeof(addr4);
+    return 1;
+  }
+  return 0;
+}
+
 vm_port_t *
 vm_native_open_file(vm_thread_t *thread, const char *filename, int direction)
 {


### PR DESCRIPTION
Introduce vm_native_parse_address so make-client can take a string literal like "aaaa::200:0:0:1" or "127.0.0.1" instead of a vector of octets or 16-bit groups. The parser dispatches per port: POSIX and JavaScript use inet_pton; Contiki and Contiki-NG use the uiplib address converter already present in the OS. Unparseable strings continue to fall through to DNS resolution.