### PR TITLE
Add sensors library and sample apps to Contiki-NG port

### DIFF
--- a/apps/embedded/sensor-scan-py.py
+++ b/apps/embedded/sensor-scan-py.py
@@ -1,0 +1,39 @@
+# Enumerate every sensor registered with Contiki-NG's sensors library,
+# read a sample from each, maintain a rolling window of recent
+# readings per sensor, and report summary statistics on every scan.
+# Intended for the Contiki-NG port - the sensors library is a platform
+# capability and is imported rather than provided as a core builtin.
+
+import sensors
+
+WINDOW = 8
+
+# Per-sensor rolling windows, lazily populated as new sensors appear.
+history = {}
+
+def compute_stats(readings):
+    n = len(readings)
+    if n == 0:
+        return [0, 0, 0]
+    return [min(readings), max(readings), sum(readings) // n]
+
+def record(name, value):
+    window = history.get(name, [])
+    window = window + [value]
+    if len(window) > WINDOW:
+        window = window[1:]
+    history[name] = window
+
+printf("Starting the sensor readings in ten seconds!")
+thread_sleep(10000)
+
+while True:
+    names = get_sensors()
+    print("=== Scan (", len(names), "sensors) ===")
+    for name in names:
+        value = sensor_value(name)
+        record(name, value)
+        stats = compute_stats(history.get(name, []))
+        print(name, ": value=", value,
+              " min=", stats[0], " max=", stats[1], " avg=", stats[2])
+#    thread_sleep(5000)

--- a/apps/embedded/sensor-scan.scm
+++ b/apps/embedded/sensor-scan.scm
@@ -1,0 +1,24 @@
+;; Enumerate every sensor registered with Contiki-NG's sensors library,
+;; read a sample from each, and log the results.  Intended for the
+;; Contiki-NG port -- the sensors library is a platform capability and
+;; is imported rather than provided as a core primitive.
+
+(import "sensors")
+
+(define read-all
+  (lambda (names)
+    (if (null? names)
+        #t
+        (begin
+          (print (car names) ": " (sensor-value (car names)) #\Newline)
+          (read-all (cdr names))))))
+
+(define scan
+  (lambda ()
+    (let ((names (get-sensors)))
+      (print "Sensors: " (length names) #\Newline)
+      (read-all names)
+      (thread-sleep! 5000)
+      (scan))))
+
+(scan)

--- a/ports/contiki-ng/create-vm-in-ram.sh
+++ b/ports/contiki-ng/create-vm-in-ram.sh
@@ -7,5 +7,5 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
-(cd ../../ && ./compile.sh $1 && echo Creating $1 in $target && rm -f ports/contiki-ng/$target && tools/create-ram-module apps/$1.vm >ports/contiki-ng/$target)
-echo "const char vm_program_name[] = \"$1.vm\";" >> $target
+(cd ../../ && ./compile.sh $1 && echo Creating $1 in $target && rm -f ports/contiki-ng/$target && tools/create-ram-module apps/$(dirname $1)/bin/$(basename $1).vm >ports/contiki-ng/$target)
+echo "const char vm_program_name[] = \"$(basename $1).vm\";" >> $target

--- a/ports/contiki-ng/vm-lib-sensors.c
+++ b/ports/contiki-ng/vm-lib-sensors.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2012-2017, RISE SICS AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Nicolas Tsiftes <nvt@acm.org>
+ */
+
+#include "contiki.h"
+
+#include "vm.h"
+#include "vm-lib.h"
+#include "vm-list.h"
+#include "vm-log.h"
+
+#if !CONTIKI_TARGET_NATIVE
+#include "lib/sensors.h"
+#endif
+
+VM_DECLARE_FUNCTION(get_sensors);
+VM_DECLARE_FUNCTION(sensor_value);
+
+static int load(vm_program_t *);
+static int unload(vm_program_t *);
+
+/* Two entries per operator: the canonical hyphenated symbol for
+ * Scheme callers and an underscore alias for Python callers (hyphens
+ * are not valid in Python identifiers).  Both aliases resolve to the
+ * same VM_FUNCTION via vm_lib_load's symbols[i] -> operators[i]
+ * mapping. */
+static const vm_procedure_t sensor_operators[] = {
+  VM_OPERATOR(get_sensors, VM_TYPE_FLAG_ANY, VM_PROCEDURE_EVAL_ARGS, 0, 0),
+  VM_OPERATOR(sensor_value, VM_TYPE_FLAG(VM_TYPE_STRING),
+              VM_PROCEDURE_EVAL_ARGS, 1, 1),
+  VM_OPERATOR(get_sensors, VM_TYPE_FLAG_ANY, VM_PROCEDURE_EVAL_ARGS, 0, 0),
+  VM_OPERATOR(sensor_value, VM_TYPE_FLAG(VM_TYPE_STRING),
+              VM_PROCEDURE_EVAL_ARGS, 1, 1)
+};
+
+vm_lib_t vm_lib_sensors = {
+  .name = "sensors",
+  .load = load,
+  .unload = unload,
+  .operators = sensor_operators,
+  .operator_count = VM_ARRAY_SIZE(sensor_operators),
+  .symbols = (const char *[]){"get-sensors", "sensor-value",
+                              "get_sensors", "sensor_value"},
+  .symbol_count = 4
+};
+
+static int
+load(vm_program_t *program)
+{
+  VM_DEBUG(VM_DEBUG_LOW, "Loading the sensors library");
+  return 1;
+}
+
+static int
+unload(vm_program_t *program)
+{
+  VM_DEBUG(VM_DEBUG_LOW, "Unloading the sensors library");
+  return 1;
+}
+
+#if CONTIKI_TARGET_NATIVE
+/* The Contiki-NG native target omits lib/sensors.c from its build,
+ * so there are no sensors to enumerate. Return empty / false to keep
+ * user programs runnable on the host. */
+
+VM_FUNCTION(get_sensors)
+{
+  vm_list_t *list;
+
+  list = vm_list_create();
+  if(list == NULL) {
+    vm_signal_error(thread, VM_ERROR_HEAP);
+    return;
+  }
+  thread->result.type = VM_TYPE_LIST;
+  thread->result.value.list = list;
+}
+
+VM_FUNCTION(sensor_value)
+{
+  VM_PUSH_BOOLEAN(VM_FALSE);
+}
+
+#else /* !CONTIKI_TARGET_NATIVE */
+
+VM_FUNCTION(get_sensors)
+{
+  const struct sensors_sensor *sensor;
+  vm_list_t *list;
+  vm_obj_t elem;
+
+  vm_gc_disable();
+
+  list = vm_list_create();
+  if(list == NULL) {
+    vm_gc_enable();
+    vm_signal_error(thread, VM_ERROR_HEAP);
+    return;
+  }
+
+  for(sensor = sensors_first(); sensor != NULL; sensor = sensors_next(sensor)) {
+    /* Skip entries without a read function (pure actuators such as
+     * relays).  Callers then know every listed name is safe to pass
+     * to sensor-value. */
+    if(sensor->value == NULL) {
+      continue;
+    }
+    if(vm_string_create(&elem, -1, sensor->type) == NULL) {
+      vm_gc_enable();
+      vm_signal_error(thread, VM_ERROR_HEAP);
+      return;
+    }
+    if(!vm_list_insert_tail(list, &elem)) {
+      vm_gc_enable();
+      vm_signal_error(thread, VM_ERROR_HEAP);
+      return;
+    }
+  }
+
+  vm_gc_enable();
+  thread->result.type = VM_TYPE_LIST;
+  thread->result.value.list = list;
+}
+
+VM_FUNCTION(sensor_value)
+{
+  const struct sensors_sensor *sensor;
+
+  sensor = sensors_find(argv[0].value.string->str);
+  if(sensor == NULL || sensor->value == NULL) {
+    /* Unknown sensor or actuator-only entry.  Signal a proper error
+     * rather than returning #f: all names from get-sensors are
+     * guaranteed to be readable, so this path is a programming error
+     * in the caller. */
+    vm_signal_error(thread, VM_ERROR_NAME);
+    vm_set_error_string(thread, "no such sensor");
+    return;
+  }
+
+  /* Activate on demand: many drivers return -1 on the first read
+   * otherwise, and leaving every sensor permanently active would
+   * waste power.  Callers that need a steady stream can do their
+   * own configure(). */
+  if(sensor->configure != NULL) {
+    sensor->configure(SENSORS_ACTIVE, 1);
+  }
+
+  VM_PUSH_INTEGER(sensor->value(0));
+}
+
+#endif /* CONTIKI_TARGET_NATIVE */

--- a/ports/contiki-ng/vm.c
+++ b/ports/contiki-ng/vm.c
@@ -42,6 +42,7 @@ extern vm_lib_t vm_lib_leds;
 extern vm_lib_t vm_lib_radio;
 extern vm_lib_t vm_lib_rpl;
 extern vm_lib_t vm_lib_crypto;
+extern vm_lib_t vm_lib_sensors;
 
 PROCESS(vm_process, VM_NAME);
 AUTOSTART_PROCESSES(&vm_process);
@@ -67,6 +68,7 @@ PROCESS_THREAD(vm_process, ev, data)
   vm_lib_register(&vm_lib_radio);
   vm_lib_register(&vm_lib_rpl);
   vm_lib_register(&vm_lib_crypto);
+  vm_lib_register(&vm_lib_sensors);
 
   process_start(&vm_perfmon_process, NULL);
 


### PR DESCRIPTION
vm-lib-sensors registers with the VM at startup and exposes the Contiki-NG sensors API to bytecode programs. sensor-scan.scm and sensor-scan-py.py demonstrate enumeration, reads, and rolling statistics. create-vm-in-ram.sh now resolves the compiled bytecode under apps/<dir>/bin/<basename>.vm to match the apps/**/bin layout.

The Python sample uses `import sensors` and min/max over an iterable, both of which require the pyvelox translator changes on the pyvelox-import-and-iterable-folds branch.