### PR TITLE
Box the ext_object union variant

### DIFF
--- a/core/expr-mutex.c
+++ b/core/expr-mutex.c
@@ -84,32 +84,41 @@ static vm_ext_type_t ext_type_mutex = {
 #define EXTRACT_MUTEX(thread, obj, target_var)               \
   do {                                                       \
     if((obj).type != VM_TYPE_EXTERNAL ||                     \
-       (obj).value.ext_object.type != &ext_type_mutex) {     \
+       (obj).value.ext_object->type != &ext_type_mutex) {    \
         vm_signal_error((thread), VM_ERROR_ARGUMENT_TYPES);  \
         return;                                              \
     }                                                        \
-    (target_var) = obj.value.ext_object.opaque_data;         \
+    (target_var) = obj.value.ext_object->opaque_data;        \
   } while(0)
 
 static void
 mutex_create(vm_obj_t *dst, const char *name)
 {
   vm_mutex_t *mutex;
+  vm_ext_object_t *ext;
 
   mutex = VM_MALLOC(sizeof(vm_mutex_t));
-  if(mutex != NULL) {
-    dst->type = VM_TYPE_EXTERNAL;
-    dst->value.ext_object.type = &ext_type_mutex;
-    dst->value.ext_object.opaque_data = mutex;
-    mutex->name = name;
-    mutex->state = 0;
-    mutex->owner_id = VM_ID_INVALID;
-    mutex->obj = NULL;
-    mutex->wait_list = NULL;
-  } else {
+  if(mutex == NULL) {
     memset(dst, 0, sizeof(vm_obj_t));
     dst->type = VM_TYPE_NONE;
+    return;
   }
+  ext = vm_alloc(sizeof(vm_ext_object_t));
+  if(ext == NULL) {
+    VM_FREE(mutex);
+    memset(dst, 0, sizeof(vm_obj_t));
+    dst->type = VM_TYPE_NONE;
+    return;
+  }
+  ext->type = &ext_type_mutex;
+  ext->opaque_data = mutex;
+  dst->value.ext_object = ext;
+  dst->type = VM_TYPE_EXTERNAL;
+  mutex->name = name;
+  mutex->state = 0;
+  mutex->owner_id = VM_ID_INVALID;
+  mutex->obj = NULL;
+  mutex->wait_list = NULL;
 }
 
 static void
@@ -125,7 +134,7 @@ mutex_deallocate(vm_obj_t *obj)
   vm_mutex_t *mutex;
   wait_thread_t *wt;
 
-  mutex = obj->value.ext_object.opaque_data;
+  mutex = obj->value.ext_object->opaque_data;
 
   /* Deallocate the wait list. */
   while(mutex->wait_list != NULL) {
@@ -142,7 +151,7 @@ mutex_write(vm_port_t *port, vm_obj_t *obj)
 {
   vm_mutex_t *mutex;
 
-  mutex = obj->value.ext_object.opaque_data;
+  mutex = obj->value.ext_object->opaque_data;
 
   vm_write(port, "(#mutex name=\"%s\" state=%u owner=%lu)", mutex->name,
            mutex->state, (unsigned long)mutex->owner_id);
@@ -151,7 +160,7 @@ mutex_write(vm_port_t *port, vm_obj_t *obj)
 VM_FUNCTION(mutexp)
 {
   VM_PUSH_BOOLEAN(argv[0].type == VM_TYPE_EXTERNAL &&
-		  argv[0].value.ext_object.type == &ext_type_mutex);
+		  argv[0].value.ext_object->type == &ext_type_mutex);
 }
 
 VM_FUNCTION(make_mutex)

--- a/core/vm-lang.c
+++ b/core/vm-lang.c
@@ -372,7 +372,7 @@ vm_write_object(vm_port_t *port, vm_obj_t *obj)
     vm_write(port, "#(libfunc %p)", obj->value.procedure);
     break;
   case VM_TYPE_EXTERNAL:
-    obj->value.ext_object.type->write(port, obj);
+    obj->value.ext_object->type->write(port, obj);
     break;
   default:
     vm_write(port, "#<unknown>");
@@ -456,8 +456,8 @@ vm_objects_equal(vm_thread_t *thread, vm_obj_t *obj1, vm_obj_t *obj2)
   case VM_TYPE_PROCEDURE:
     return obj1->value.procedure == obj2->value.procedure;
   case VM_TYPE_EXTERNAL:
-    return obj1->value.ext_object.type == obj2->value.ext_object.type &&
-      obj1->value.ext_object.opaque_data == obj2->value.ext_object.opaque_data;
+    return obj1->value.ext_object->type == obj2->value.ext_object->type &&
+      obj1->value.ext_object->opaque_data == obj2->value.ext_object->opaque_data;
   default:
     break;
   }
@@ -528,7 +528,7 @@ vm_object_deep_copy(vm_obj_t *old, vm_obj_t *new)
   case VM_TYPE_VECTOR:
     break;
   case VM_TYPE_EXTERNAL:
-    old->value.ext_object.type->copy(new, old);
+    old->value.ext_object->type->copy(new, old);
     break;
   default:
     break;

--- a/core/vm-lib-complex.c
+++ b/core/vm-lib-complex.c
@@ -100,18 +100,27 @@ static void
 complex_create(vm_obj_t *dst, vm_real_t real, vm_real_t imag)
 {
   vm_complex_t *complex;
+  vm_ext_object_t *ext;
 
   complex = VM_MALLOC(sizeof(vm_complex_t));
-  if(complex != NULL) {
-    dst->type = VM_TYPE_EXTERNAL;
-    dst->value.ext_object.type = &ext_type_complex;
-    dst->value.ext_object.opaque_data = complex;
-    complex->real = real;
-    complex->imag = imag;
-  } else {
+  if(complex == NULL) {
     memset(dst, 0, sizeof(vm_obj_t));
     dst->type = VM_TYPE_NONE;
+    return;
   }
+  ext = vm_alloc(sizeof(vm_ext_object_t));
+  if(ext == NULL) {
+    VM_FREE(complex);
+    memset(dst, 0, sizeof(vm_obj_t));
+    dst->type = VM_TYPE_NONE;
+    return;
+  }
+  ext->type = &ext_type_complex;
+  ext->opaque_data = complex;
+  dst->value.ext_object = ext;
+  dst->type = VM_TYPE_EXTERNAL;
+  complex->real = real;
+  complex->imag = imag;
 }
 
 static void
@@ -123,7 +132,7 @@ complex_copy(vm_obj_t *dst, vm_obj_t *src)
 static void
 complex_deallocate(vm_obj_t *obj)
 {
-  VM_FREE(obj->value.ext_object.opaque_data);
+  VM_FREE(obj->value.ext_object->opaque_data);
 }
 
 static void
@@ -131,7 +140,7 @@ complex_write(vm_port_t *port, vm_obj_t *obj)
 {
   vm_complex_t *complex;
 
-  complex = obj->value.ext_object.opaque_data;
+  complex = obj->value.ext_object->opaque_data;
 
   vm_write(port, "%ld+%ldi", (long)complex->real, (long)complex->imag);
 }
@@ -166,8 +175,8 @@ get_real(vm_obj_t *obj)
   case VM_TYPE_REAL:
     return obj->value.real;
   case VM_TYPE_EXTERNAL:
-    if(obj->value.ext_object.type == &ext_type_complex) {
-      vm_complex_t *complex = obj->value.ext_object.opaque_data;
+    if(obj->value.ext_object->type == &ext_type_complex) {
+      vm_complex_t *complex = obj->value.ext_object->opaque_data;
       return complex->real;
     }
     /* Fall through. */
@@ -182,11 +191,11 @@ static vm_complex_t *
 get_complex(vm_obj_t *obj)
 {
   if(obj->type != VM_TYPE_EXTERNAL ||
-     obj->value.ext_object.type != &ext_type_complex) {
+     obj->value.ext_object->type != &ext_type_complex) {
     return 0;
   }
 
-  return obj->value.ext_object.opaque_data;
+  return obj->value.ext_object->opaque_data;
 }
 
 VM_FUNCTION(make_rectangular)
@@ -230,8 +239,8 @@ VM_FUNCTION(magnitude)
   vm_real_t imag;
 
   if(argv[0].type == VM_TYPE_EXTERNAL &&
-     argv[0].value.ext_object.type == &ext_type_complex) {
-    complex = argv[0].value.ext_object.opaque_data;
+     argv[0].value.ext_object->type == &ext_type_complex) {
+    complex = argv[0].value.ext_object->opaque_data;
     real = complex->real;
     imag = complex->imag;
   } else {

--- a/core/vm-memory.c
+++ b/core/vm-memory.c
@@ -175,6 +175,13 @@ mark_object(vm_obj_t *obj)
     }
     mark_memory(obj->value.vector);
     break;
+  case VM_TYPE_EXTERNAL:
+    /* The ext_object box is heap-allocated; mark it so the sweep
+       phase does not free it while the parent obj is still live. */
+    if(obj->value.ext_object != NULL) {
+      mark_memory(obj->value.ext_object);
+    }
+    break;
   default:
     break;
   }

--- a/core/vm-thread.c
+++ b/core/vm-thread.c
@@ -61,7 +61,7 @@ thread_obj_write(vm_port_t *port, vm_obj_t *obj)
 {
   vm_thread_t *thread;
 
-  thread = obj->value.ext_object.opaque_data;
+  thread = obj->value.ext_object->opaque_data;
   vm_write(port, "#<thread %ld>", (long)thread->id);
 }
 
@@ -131,9 +131,19 @@ vm_thread_init(void)
 void
 thread_obj_create(vm_obj_t *obj, vm_thread_t *thread)
 {
+  vm_ext_object_t *ext;
+
+  ext = vm_alloc(sizeof(vm_ext_object_t));
+  if(ext == NULL) {
+    /* No callers propagate a failure code; fall back to VM_TYPE_NONE
+       to keep the object well-formed. */
+    obj->type = VM_TYPE_NONE;
+    return;
+  }
+  ext->type = &ext_type_thread;
+  ext->opaque_data = thread;
+  obj->value.ext_object = ext;
   obj->type = VM_TYPE_EXTERNAL;
-  obj->value.ext_object.type = &ext_type_thread;
-  obj->value.ext_object.opaque_data = thread;
 }
 
 void

--- a/include/vm-objects.h
+++ b/include/vm-objects.h
@@ -202,7 +202,7 @@ typedef union vm_obj_value {
   vm_vector_t *vector;
   vm_port_t *port;
   const struct vm_procedure *procedure;
-  struct vm_ext_object ext_object;
+  struct vm_ext_object *ext_object;
 } vm_obj_value_t;
 
 /* VM objects consist of a type specifier and its corresponding


### PR DESCRIPTION
Change vm_obj_value_t::ext_object from inline struct to pointer. The union's largest variant becomes 8 B (was 16 B), so vm_obj_t shrinks 24->16 B and vm_list_item_t 32->24 B. Inline-obj-heavy structures (cons cells, vector element arrays, frame argv) shrink proportionally.