### PR TITLE
Finalize ext-objects via a side-table walked by the GC

### DIFF
--- a/core/expr-mutex.c
+++ b/core/expr-mutex.c
@@ -95,7 +95,6 @@ static void
 mutex_create(vm_obj_t *dst, const char *name)
 {
   vm_mutex_t *mutex;
-  vm_ext_object_t *ext;
 
   mutex = VM_MALLOC(sizeof(vm_mutex_t));
   if(mutex == NULL) {
@@ -103,17 +102,10 @@ mutex_create(vm_obj_t *dst, const char *name)
     dst->type = VM_TYPE_NONE;
     return;
   }
-  ext = vm_alloc(sizeof(vm_ext_object_t));
-  if(ext == NULL) {
+  if(vm_ext_object_create(dst, &ext_type_mutex, mutex) == NULL) {
     VM_FREE(mutex);
-    memset(dst, 0, sizeof(vm_obj_t));
-    dst->type = VM_TYPE_NONE;
     return;
   }
-  ext->type = &ext_type_mutex;
-  ext->opaque_data = mutex;
-  dst->value.ext_object = ext;
-  dst->type = VM_TYPE_EXTERNAL;
   mutex->name = name;
   mutex->state = 0;
   mutex->owner_id = VM_ID_INVALID;

--- a/core/vm-lib-complex.c
+++ b/core/vm-lib-complex.c
@@ -100,7 +100,6 @@ static void
 complex_create(vm_obj_t *dst, vm_real_t real, vm_real_t imag)
 {
   vm_complex_t *complex;
-  vm_ext_object_t *ext;
 
   complex = VM_MALLOC(sizeof(vm_complex_t));
   if(complex == NULL) {
@@ -108,17 +107,10 @@ complex_create(vm_obj_t *dst, vm_real_t real, vm_real_t imag)
     dst->type = VM_TYPE_NONE;
     return;
   }
-  ext = vm_alloc(sizeof(vm_ext_object_t));
-  if(ext == NULL) {
+  if(vm_ext_object_create(dst, &ext_type_complex, complex) == NULL) {
     VM_FREE(complex);
-    memset(dst, 0, sizeof(vm_obj_t));
-    dst->type = VM_TYPE_NONE;
     return;
   }
-  ext->type = &ext_type_complex;
-  ext->opaque_data = complex;
-  dst->value.ext_object = ext;
-  dst->type = VM_TYPE_EXTERNAL;
   complex->real = real;
   complex->imag = imag;
 }

--- a/core/vm-memory.c
+++ b/core/vm-memory.c
@@ -90,6 +90,15 @@ static vm_memory_stats_t mem_stats;
  */
 static int gc_disabled = 0;
 
+/*
+ * Singly-linked list of every live vm_ext_object_t allocated via
+ * vm_ext_object_create. The GC walks this list after marking to call
+ * each unreferenced box's type->deallocate callback, freeing the
+ * type-specific opaque_data backing that the GC's heap sweep cannot
+ * see otherwise.
+ */
+static vm_ext_object_t *ext_object_list_head = NULL;
+
 static void
 free_vm_memory(void *ptr)
 {
@@ -302,6 +311,19 @@ vm_free_all(void)
 {
   unsigned i;
   unsigned deallocated;
+  vm_ext_object_t *box;
+  vm_obj_t obj;
+
+  /* Finalize every remaining ext-object so each type's deallocate
+     callback runs before we tear the heap down underneath it. */
+  while((box = ext_object_list_head) != NULL) {
+    ext_object_list_head = box->next;
+    if(box->type != NULL && box->type->deallocate != NULL) {
+      obj.type = VM_TYPE_EXTERNAL;
+      obj.value.ext_object = box;
+      box->type->deallocate(&obj);
+    }
+  }
 
   for(i = deallocated = 0; i < allocations.size; i++) {
     if(VM_HASH_SLOT_USED(&allocations, i)) {
@@ -329,6 +351,39 @@ vm_gc_enable(void)
 {
   if(gc_disabled > 0) {
     gc_disabled--;
+  }
+}
+
+/*
+ * Walk the live-ext-objects list and finalize any box that the mark
+ * phase did not reach. Calling type->deallocate gives the type a chance
+ * to free its opaque_data backing (mutex struct, complex struct, etc.)
+ * before the upcoming heap sweep frees the box itself.
+ *
+ * We unlink finalized boxes from the list but do not free the box
+ * memory here -- that happens in the heap sweep that runs immediately
+ * after, since the box was registered in the heap allocations hash by
+ * vm_alloc and is what the mark bit is keyed on.
+ */
+static void
+finalize_unmarked_ext_objects(void)
+{
+  vm_ext_object_t **link;
+  vm_ext_object_t *box;
+  vm_obj_t obj;
+
+  link = &ext_object_list_head;
+  while((box = *link) != NULL) {
+    if(memory_is_marked(box)) {
+      link = &box->next;
+      continue;
+    }
+    if(box->type != NULL && box->type->deallocate != NULL) {
+      obj.type = VM_TYPE_EXTERNAL;
+      obj.value.ext_object = box;
+      box->type->deallocate(&obj);
+    }
+    *link = box->next;
   }
 }
 
@@ -361,6 +416,11 @@ do_gc(int force)
       mark_thread_references(thread);
     }
   }
+
+  /* Run external-object finalizers before the sweep so each
+     type->deallocate callback can free its opaque_data backing while
+     the box is still valid. */
+  finalize_unmarked_ext_objects();
 
   /* Sweep phase: deallocate all unreferenced objects allocated on the heap. */
   for(i = deallocated = 0; i < allocations.size; i++) {
@@ -403,6 +463,34 @@ void
 vm_gc_force(void)
 {
   do_gc(1);
+}
+
+vm_ext_object_t *
+vm_ext_object_create(vm_obj_t *dst, vm_ext_type_t *type, void *opaque_data)
+{
+  vm_ext_object_t *box;
+
+  /* Disable GC across the multi-step setup so a sweep in the middle of
+     vm_alloc cannot observe an unreferenced half-built box. */
+  vm_gc_disable();
+
+  box = vm_alloc(sizeof(vm_ext_object_t));
+  if(box == NULL) {
+    vm_gc_enable();
+    memset(dst, 0, sizeof(vm_obj_t));
+    dst->type = VM_TYPE_NONE;
+    return NULL;
+  }
+  box->type = type;
+  box->opaque_data = opaque_data;
+  box->next = ext_object_list_head;
+  ext_object_list_head = box;
+
+  dst->value.ext_object = box;
+  dst->type = VM_TYPE_EXTERNAL;
+
+  vm_gc_enable();
+  return box;
 }
 
 void

--- a/core/vm-thread.c
+++ b/core/vm-thread.c
@@ -131,19 +131,10 @@ vm_thread_init(void)
 void
 thread_obj_create(vm_obj_t *obj, vm_thread_t *thread)
 {
-  vm_ext_object_t *ext;
-
-  ext = vm_alloc(sizeof(vm_ext_object_t));
-  if(ext == NULL) {
-    /* No callers propagate a failure code; fall back to VM_TYPE_NONE
-       to keep the object well-formed. */
-    obj->type = VM_TYPE_NONE;
-    return;
-  }
-  ext->type = &ext_type_thread;
-  ext->opaque_data = thread;
-  obj->value.ext_object = ext;
-  obj->type = VM_TYPE_EXTERNAL;
+  /* No callers propagate a failure code; vm_ext_object_create sets the
+     dst to VM_TYPE_NONE on allocation failure, leaving the object well
+     formed. */
+  vm_ext_object_create(obj, &ext_type_thread, thread);
 }
 
 void

--- a/include/vm-objects.h
+++ b/include/vm-objects.h
@@ -180,6 +180,11 @@ struct vm_ext_type;
 typedef struct vm_ext_object {
   struct vm_ext_type *type;
   void *opaque_data;
+  /* Linkage for the global live-objects list maintained in vm-memory.c.
+     The GC walks this list after the mark phase to invoke each unmarked
+     box's type->deallocate callback before reclaiming the box. Internal
+     to the runtime; do not access from outside core/vm-memory.c. */
+  struct vm_ext_object *next;
 } vm_ext_object_t;
 
 /* Forward reference to a type definition needed by vm_obj_value_t. */

--- a/include/vm.h
+++ b/include/vm.h
@@ -268,6 +268,16 @@ int vm_memory_init(void);
 const vm_mempool_t *vm_object_pool(void);
 void vm_memory_profile_print(void);
 
+/* Allocate a vm_ext_object_t, fill its type/opaque_data, link it onto
+   the GC's live-objects list, and store the box pointer in dst (also
+   setting dst->type to VM_TYPE_EXTERNAL). Returns the box on success,
+   or NULL on allocation failure with dst zeroed and dst->type set to
+   VM_TYPE_NONE. The caller still owns opaque_data; the type's
+   deallocate callback is responsible for freeing it. */
+vm_ext_object_t *vm_ext_object_create(vm_obj_t *dst,
+                                       vm_ext_type_t *type,
+                                       void *opaque_data);
+
 /* Thread functions. (vm-thread.c) */
 int vm_thread_init(void);
 void thread_obj_create(vm_obj_t *, vm_thread_t *);


### PR DESCRIPTION
The deallocate callback on vm_ext_type_t had been declared by every ext-type but never invoked. opaque_data backings (mutex structs, complex structs) leaked once their parent object became unreachable.

Thread each vm_ext_object_t onto a singly-linked list maintained in vm-memory.c, populated by a new vm_ext_object_create helper that the three construction sites (mutex_create, complex_create, thread_obj_create) now use. After the mark phase, the GC walks the list, calls type->deallocate(obj) on every unreferenced box, and unlinks it; the heap sweep then frees the box memory itself. On shutdown, vm_free_all drains the list with the same callback so every backing is reclaimed even when no GC ran.