### PR TITLE
Tag pool allocations with category and emit a per-site histogram

### DIFF
--- a/core/vm-bytecode.c
+++ b/core/vm-bytecode.c
@@ -200,7 +200,8 @@ vm_get_object(vm_thread_t *thread, vm_obj_t *obj)
     if(!VM_STEP(thread)) {
       return;
     }
-    obj->value.rational = vm_alloc(sizeof(vm_rational_t));
+    obj->value.rational = vm_alloc_at(sizeof(vm_rational_t),
+                                      VM_ALLOC_SITE_RATIONAL);
     if(obj->value.rational == NULL) {
       vm_signal_error(thread, VM_ERROR_HEAP);
       return;
@@ -221,7 +222,8 @@ vm_get_object(vm_thread_t *thread, vm_obj_t *obj)
         return;
       }
 
-      obj->value.string = vm_alloc(sizeof(vm_string_t));
+      obj->value.string = vm_alloc_at(sizeof(vm_string_t),
+                                      VM_ALLOC_SITE_STRING_HEADER);
       if(obj->value.string == NULL) {
         vm_signal_error(thread, VM_ERROR_HEAP);
         return;

--- a/core/vm-list.c
+++ b/core/vm-list.c
@@ -41,7 +41,7 @@ vm_list_create(void)
 {
   vm_list_t *list;
 
-  list = vm_alloc(sizeof(vm_list_t));
+  list = vm_alloc_at(sizeof(vm_list_t), VM_ALLOC_SITE_LIST_HEADER);
   if(list != NULL) {
     list->head = NULL;
     list->tail = NULL;
@@ -128,7 +128,7 @@ vm_list_cdr(vm_list_t *list, int copy)
        of the new list structure before it's stored */
     vm_gc_disable();
 
-    cdr_list = vm_alloc(sizeof(vm_list_t));
+    cdr_list = vm_alloc_at(sizeof(vm_list_t), VM_ALLOC_SITE_LIST_HEADER);
     if(cdr_list != NULL) {
       cdr_list->head = list->head->next;
       cdr_list->length = list->length - 1;
@@ -166,7 +166,8 @@ vm_list_set_cdr(vm_list_t *list, vm_obj_t *obj)
   if(list->head == NULL) {
     return VM_FALSE;
   }
-  list->head->next = vm_alloc(sizeof(vm_list_item_t));
+  list->head->next = vm_alloc_at(sizeof(vm_list_item_t),
+                                 VM_ALLOC_SITE_CONS_CELL);
   if(list->head->next == NULL) {
     return VM_FALSE;
   }
@@ -203,7 +204,7 @@ vm_list_insert_head(vm_list_t *list, vm_obj_t *obj)
 {
   vm_list_item_t *item;
 
-  item = vm_alloc(sizeof(vm_list_item_t));
+  item = vm_alloc_at(sizeof(vm_list_item_t), VM_ALLOC_SITE_CONS_CELL);
   if(item != NULL) {
     memcpy(&item->obj, obj, sizeof(vm_obj_t));
     list->length++;
@@ -223,7 +224,7 @@ vm_list_insert_tail(vm_list_t *list, vm_obj_t *obj)
 {
   vm_list_item_t *item;
 
-  item = vm_alloc(sizeof(vm_list_item_t));
+  item = vm_alloc_at(sizeof(vm_list_item_t), VM_ALLOC_SITE_CONS_CELL);
   if(item != NULL) {
     memcpy(&item->obj, obj, sizeof(vm_obj_t));
     list->length++;

--- a/core/vm-memory.c
+++ b/core/vm-memory.c
@@ -465,6 +465,22 @@ vm_gc_force(void)
   do_gc(1);
 }
 
+#if VM_ATTRIBUTION_ENABLE
+void *
+vm_alloc_at(unsigned size, vm_alloc_site_t site)
+{
+  void *ptr;
+  vm_mempool_index_t index;
+
+  ptr = vm_alloc(size);
+  if(ptr != NULL && vm_mempool_is_stored(&object_pool, ptr)) {
+    index = ((char *)ptr - object_pool.heap) / object_pool.obj_size;
+    object_pool.alloc_sites[index] = (uint8_t)site;
+  }
+  return ptr;
+}
+#endif
+
 vm_ext_object_t *
 vm_ext_object_create(vm_obj_t *dst, vm_ext_type_t *type, void *opaque_data)
 {
@@ -474,7 +490,7 @@ vm_ext_object_create(vm_obj_t *dst, vm_ext_type_t *type, void *opaque_data)
      vm_alloc cannot observe an unreferenced half-built box. */
   vm_gc_disable();
 
-  box = vm_alloc(sizeof(vm_ext_object_t));
+  box = vm_alloc_at(sizeof(vm_ext_object_t), VM_ALLOC_SITE_EXT_OBJECT);
   if(box == NULL) {
     vm_gc_enable();
     memset(dst, 0, sizeof(vm_obj_t));
@@ -509,6 +525,48 @@ void
 vm_memory_profile_print(void)
 {
   vm_mempool_stats_t stats;
+
+#if VM_ATTRIBUTION_ENABLE
+  {
+    /* Snapshot the per-site occupancy of the object pool BEFORE any
+       force-GC runs, so the histogram reflects what was still
+       resident at the moment of the print rather than the post-sweep
+       residue (which is zero by construction). */
+    static const char *const site_names[VM_ALLOC_SITE_COUNT] = {
+      [VM_ALLOC_SITE_OTHER]           = "other",
+      [VM_ALLOC_SITE_CONS_CELL]       = "cons",
+      [VM_ALLOC_SITE_LIST_HEADER]     = "list_hdr",
+      [VM_ALLOC_SITE_VECTOR_HEADER]   = "vec_hdr",
+      [VM_ALLOC_SITE_VECTOR_ELEMENTS] = "vec_elems",
+      [VM_ALLOC_SITE_VECTOR_BYTES]    = "vec_bytes",
+      [VM_ALLOC_SITE_STRING_HEADER]   = "str_hdr",
+      [VM_ALLOC_SITE_STRING_BUFFER]   = "str_buf",
+      [VM_ALLOC_SITE_RATIONAL]        = "rational",
+      [VM_ALLOC_SITE_EXT_OBJECT]      = "ext_obj",
+    };
+    uint32_t counts[VM_ALLOC_SITE_COUNT] = {0};
+    vm_mempool_index_t i;
+    unsigned byte;
+    unsigned bit;
+    int s;
+
+    for(i = 0; i < object_pool.capacity; i++) {
+      byte = i / (sizeof(vm_mempool_bitmap_t) * 8);
+      bit = 1U << (i % (sizeof(vm_mempool_bitmap_t) * 8));
+      if(VM_IS_SET(object_pool.alloc_bitmap[byte], bit)) {
+        uint8_t site = object_pool.alloc_sites[i];
+        if(site < VM_ALLOC_SITE_COUNT) {
+          counts[site]++;
+        }
+      }
+    }
+    printf("MEM objpool by_site");
+    for(s = 0; s < VM_ALLOC_SITE_COUNT; s++) {
+      printf(" %s=%lu", site_names[s], (unsigned long)counts[s]);
+    }
+    printf("\n");
+  }
+#endif
 
 #if VM_MEMORY_PROFILING_GC
   /* Force a sweep so the "used" numbers reflect live memory rather

--- a/core/vm-mempool.c
+++ b/core/vm-mempool.c
@@ -135,6 +135,20 @@ vm_mempool_create(vm_mempool_t *pool, uint16_t obj_size,
     return 0;
   }
 
+#if VM_ATTRIBUTION_ENABLE
+  pool->alloc_sites = VM_MEMPOOL_ALLOC(capacity);
+  if(pool->alloc_sites == NULL) {
+    VM_MEMPOOL_FREE(pool->alloc_bitmap);
+    VM_MEMPOOL_FREE(pool->ref_bitmap);
+    VM_MEMPOOL_FREE(pool->heap);
+    VM_DEBUG(VM_DEBUG_MEDIUM,
+             "Failed to create a mempool sites array of size %lu\n",
+             (unsigned long)capacity);
+    return 0;
+  }
+  memset(pool->alloc_sites, 0, capacity);
+#endif
+
   return 1;
 }
 
@@ -152,6 +166,9 @@ vm_mempool_destroy(vm_mempool_t *pool)
   VM_MEMPOOL_FREE(pool->alloc_bitmap);
   VM_MEMPOOL_FREE(pool->ref_bitmap);
   VM_MEMPOOL_FREE(pool->heap);
+#if VM_ATTRIBUTION_ENABLE
+  VM_MEMPOOL_FREE(pool->alloc_sites);
+#endif
   pool->items = 0;
   pool->capacity = 0;
 }
@@ -186,6 +203,9 @@ vm_mempool_alloc(vm_mempool_t *pool)
   update_next_free_index(pool);
 
   VM_SET_FLAG(pool->alloc_bitmap[byte], bit);
+#if VM_ATTRIBUTION_ENABLE
+  pool->alloc_sites[index] = 0;  /* VM_ALLOC_SITE_OTHER */
+#endif
   return (char *)pool->heap + index * pool->obj_size;
 }
 

--- a/core/vm-objects.c
+++ b/core/vm-objects.c
@@ -59,7 +59,8 @@ vm_string_create(vm_obj_t *obj, vm_integer_t length, const char *str)
   }
 
   obj->type = VM_TYPE_STRING;
-  obj->value.string = vm_alloc(sizeof(vm_string_t));
+  obj->value.string = vm_alloc_at(sizeof(vm_string_t),
+                                  VM_ALLOC_SITE_STRING_HEADER);
   if(obj->value.string == NULL) {
     return NULL;
   }
@@ -70,7 +71,7 @@ vm_string_create(vm_obj_t *obj, vm_integer_t length, const char *str)
     return NULL;
   }
   string->length = final_length;
-  string->str = vm_alloc(final_length + 1);
+  string->str = vm_alloc_at(final_length + 1, VM_ALLOC_SITE_STRING_BUFFER);
   if(string->str == NULL) {
     return NULL;
   }
@@ -118,7 +119,8 @@ vm_vector_create(vm_obj_t *obj, vm_integer_t length, vm_vector_flags_t flags)
   }
 
   obj->type = VM_TYPE_VECTOR;
-  obj->value.vector = vm_alloc(sizeof(vm_vector_t));
+  obj->value.vector = vm_alloc_at(sizeof(vm_vector_t),
+                                  VM_ALLOC_SITE_VECTOR_HEADER);
   if(obj->value.vector == NULL) {
     return NULL;
   }
@@ -131,14 +133,16 @@ vm_vector_create(vm_obj_t *obj, vm_integer_t length, vm_vector_flags_t flags)
     vector->elements = NULL;
     vector->bytes = NULL;
   } else if(VM_IS_SET(vector->flags, VM_VECTOR_FLAG_BUFFER)) {
-    vector->bytes = vm_alloc(sizeof(uint8_t) * vector->length);
+    vector->bytes = vm_alloc_at(sizeof(uint8_t) * vector->length,
+                                VM_ALLOC_SITE_VECTOR_BYTES);
     if(vector->bytes == NULL) {
       return NULL;
     }
     memset(vector->bytes, 0, vector->length);
     vector->elements = NULL;
   } else {
-    vector->elements = vm_alloc(sizeof(vm_obj_t) * vector->length);
+    vector->elements = vm_alloc_at(sizeof(vm_obj_t) * vector->length,
+                                   VM_ALLOC_SITE_VECTOR_ELEMENTS);
     if(vector->elements == NULL) {
       return NULL;
     }

--- a/include/vm-mempool.h
+++ b/include/vm-mempool.h
@@ -35,6 +35,8 @@
 
 #include <stdint.h>
 
+#include "vm-config.h"
+
 typedef uint32_t vm_mempool_index_t;
 typedef unsigned vm_mempool_bitmap_t;
 
@@ -47,6 +49,12 @@ typedef struct vm_mempool {
   vm_mempool_index_t peak_items;
   vm_mempool_index_t capacity;
   uint16_t obj_size;
+#if VM_ATTRIBUTION_ENABLE
+  /* Parallel to alloc_bitmap, one byte per slot. Stores the
+     vm_alloc_site_t recorded by vm_mempool_alloc_at; read by the
+     attribution histogram printer. */
+  uint8_t *alloc_sites;
+#endif
 } vm_mempool_t;
 
 typedef struct vm_mempool_stats {

--- a/include/vm.h
+++ b/include/vm.h
@@ -255,8 +255,31 @@ int vm_object_deep_copy(vm_obj_t *, vm_obj_t *);
 /* String utilities. (vm-symbols.c) */
 int vm_strcasecmp(const char *, const char *);
 
+/* Allocation-site categories used by the attribution profiler. The
+   ordering is the order in which categories are emitted in the
+   histogram; keep VM_ALLOC_SITE_OTHER at index 0 so that
+   zero-initialised slots fall into the catch-all bucket. */
+typedef enum vm_alloc_site {
+  VM_ALLOC_SITE_OTHER = 0,
+  VM_ALLOC_SITE_CONS_CELL,
+  VM_ALLOC_SITE_LIST_HEADER,
+  VM_ALLOC_SITE_VECTOR_HEADER,
+  VM_ALLOC_SITE_VECTOR_ELEMENTS,
+  VM_ALLOC_SITE_VECTOR_BYTES,
+  VM_ALLOC_SITE_STRING_HEADER,
+  VM_ALLOC_SITE_STRING_BUFFER,
+  VM_ALLOC_SITE_RATIONAL,
+  VM_ALLOC_SITE_EXT_OBJECT,
+  VM_ALLOC_SITE_COUNT
+} vm_alloc_site_t;
+
 /* Memory functions. (vm-memory.c) */
 void *vm_alloc(unsigned);
+#if VM_ATTRIBUTION_ENABLE
+void *vm_alloc_at(unsigned, vm_alloc_site_t);
+#else
+#define vm_alloc_at(size, site) vm_alloc((size))
+#endif
 void vm_free(void *);
 void vm_free_all(void);
 void vm_gc(void);

--- a/ports/contiki-ng/vm-config.h
+++ b/ports/contiki-ng/vm-config.h
@@ -86,6 +86,15 @@
 #define VM_MEMORY_PROFILING_GC 0
 #endif
 
+/* Tag every pool allocation with a category enum (cons cell, string
+   header, vector elements, etc.) and emit a per-category histogram
+   from the memory profiler. Adds 1 byte per pool slot plus a small
+   fixed alloc-time cost. Off by default; enable in addition to
+   VM_MEMORY_PROFILING for attribution data. */
+#ifndef VM_ATTRIBUTION_ENABLE
+#define VM_ATTRIBUTION_ENABLE 0
+#endif
+
 /*
  * Determine whether instruction profiling should be enabled.
  * This can be used to gain insight into the performance bottlenecks

--- a/ports/posix/vm-config.h
+++ b/ports/posix/vm-config.h
@@ -84,6 +84,15 @@
 #define VM_MEMORY_PROFILING_GC 1
 #endif
 
+/* Tag every pool allocation with a category enum (cons cell, string
+   header, vector elements, etc.) and emit a per-category histogram from
+   the memory profiler. Adds 1 byte per pool slot plus a small fixed
+   alloc-time cost. Off by default; enable in addition to
+   VM_MEMORY_PROFILING for attribution data. */
+#ifndef VM_ATTRIBUTION_ENABLE
+#define VM_ATTRIBUTION_ENABLE 0
+#endif
+
 /*
  * Determine whether instruction profiling should be enabled.
  * This can be used to gain insight into the performance bottlenecks


### PR DESCRIPTION
Add a compile-time VM_ATTRIBUTION_ENABLE knob (default off) that extends the memory profiler with a per-category breakdown of currently allocated object-pool slots.