### PR TITLE
Fix calls whose operator is a computed sub-expression

### DIFF
--- a/core/vm-sched.c
+++ b/core/vm-sched.c
@@ -384,8 +384,33 @@ restart:
     vm_thread_stack_pop(thread);
     expr = thread->expr;
 
+    /* Snapshot argv[0] before overwrite: if arg 0 was a sub-expression in
+       operator position (VM_FORM_REF), the result is the operator value
+       and must trigger lambda execution. If it was already a lambda or
+       closure being invoked (loaded inline as VM_FORM_LAMBDA or stored
+       in argv[0] as a VM_TYPE_CLOSURE before dispatch), the result is the
+       body's return value and must not re-invoke. */
+    int prev_arg0_was_subexpr =
+      (expr->eval_arg == 0 &&
+       expr->argv[0].type == VM_TYPE_FORM &&
+       expr->argv[0].value.form.type == VM_FORM_REF);
+
     VM_EVAL_SET_COMPLETED(thread, expr->eval_arg);
     memmove(&expr->argv[expr->eval_arg], &thread->result, sizeof(vm_obj_t));
+
+    /* When evaluating a sub-expression in operator position produced a
+       lambda or closure (e.g. ((box-ref f) 0) or ((make-fn) x)), set up
+       lambda execution here -- the first-load hook around line 230 only
+       handles inline-loaded operators. The completed bit on arg 0 is
+       cleared so the eval loop dispatches into the lambda body just as
+       it would for an inline-loaded lambda. */
+    if(prev_arg0_was_subexpr &&
+       ((expr->argv[0].type == VM_TYPE_FORM &&
+         expr->argv[0].value.form.type == VM_FORM_LAMBDA) ||
+        expr->argv[0].type == VM_TYPE_CLOSURE)) {
+      init_lambda_execution(thread, expr);
+      expr->eval_completed &= ~(1U << 0);
+    }
   } else if(expr->ip == expr->end) {
     /* We have executed the last instruction of the top-level expr; the program
        is therefore finished. */

--- a/languages/scheme-racket/compiler.rkt
+++ b/languages/scheme-racket/compiler.rkt
@@ -477,13 +477,17 @@
 
 (define (compile-application expr bc [env '()])
   ;; Function application: (func arg1 arg2 ...)
-  ;; The function position is always embedded inline (compile-expr handles
-  ;; the symbol / lambda-form / etc. case directly); each argument goes
-  ;; through compile-subexpr.
+  ;; Both the function position and each argument go through compile-subexpr:
+  ;; compound sub-expressions are lifted into the expression table as form-refs
+  ;; so the runtime sees a single token. Inlining a compound operator (e.g.
+  ;; ((box-ref loop) 0)) corrupts byte parsing because vm_get_object advances
+  ;; past the inline header only, leaving the inner body to be misread as the
+  ;; outer call's arguments. Atoms and lambdas remain inlined since they
+  ;; encode as a single token.
   (let* ([func (car expr)]
          [args (cdr expr)]
          [total-count (+ 1 (length args))]
-         [func-enc (compile-expr func bc env)]
+         [func-enc (compile-subexpr func bc env)]
          [arg-encs (map (lambda (arg) (compile-subexpr arg bc env)) args)])
     (expr-encoding 'form
                    (append (expr-encoding-data (encode-form-inline total-count))

--- a/tests/unit-tests/vm-specific/test-closures.scm
+++ b/tests/unit-tests/vm-specific/test-closures.scm
@@ -100,4 +100,20 @@
 (assert-equal 1 (nc) "primitive-named local: first call")
 (assert-equal 2 (nc) "primitive-named local: second call")
 
+;; Operator position is a sub-expression that returns a callable.
+;; The compiler lifts a compound operator into a form-ref; the runtime
+;; recognizes a sub-expression operator and invokes the resulting
+;; lambda/closure.
+(define (get-doubler) (lambda (x) (* x 2)))
+(assert-equal 14 ((get-doubler) 7) "call result of a 0-arg getter")
+
+;; Named let -- rewrites to letrec which rewrites to a captured-and-mutated
+;; outer parameter holding the recursive function. The recursive call site
+;; ((box-ref loop) ...) hits the same operator-as-sub-expression path.
+(define (count-down n)
+  (let loop ((i n) (acc 0))
+    (if (= i 0) acc (loop (- i 1) (+ acc 1)))))
+(assert-equal 5 (count-down 5) "named let counting down")
+(assert-equal 0 (count-down 0) "named let zero iterations")
+
 (test-summary)


### PR DESCRIPTION
((some-call) arg), where the operator is itself a function call, silently misbehaved. The bytecode encoder embedded the operator as an inline form, but the runtime byte loader advances past only the inline header (leaving the inner body in the stream). The outer reader then misread that body as its own argv, so the actual operator value never reached argv[0] and the expected args were skipped or fell off the end.

The pattern is rare in user-written code because most operators are bound names, but the named-let -> letrec -> (set! loop (lambda ...)) -> ((box-ref loop) ...) chain produces it on every recursive iteration, breaking any (let loop () ...) form whose body recurses.

Two changes:

  * Compiler (compile-application): route the operator through compile-subexpr instead of compile-expr. Compound operators are lifted into the expression table as form-refs; symbols and lambdas still encode inline since both fit in a single token. This avoids the nested-inline-form parsing hazard at the source.

  * Runtime (vm-sched.c): the existing first-load hook only fires when argv[0] is a directly-loaded lambda or closure. When argv[0] came through sub-expression evaluation, it was previously a form-ref placeholder -- now overwritten with the operator's value. Add a second hook at the stack-pop site that fires only on that transition (guarded by the pre-overwrite type being VM_FORM_REF so it cannot misinterpret the lambda body's return value as a new operator).