### PR TITLE
Eval symbol-typed arguments in the define primitive

### DIFF
--- a/core/expr-primitives.c
+++ b/core/expr-primitives.c
@@ -322,10 +322,15 @@ VM_FUNCTION(define)
   } else {
     /* Object definition. */
 
-    if(argv[1].type == VM_TYPE_FORM &&
-       argv[1].value.form.type != VM_FORM_LAMBDA &&
-       !VM_EVAL_ARG_DONE(thread, 1)) {
-      /* Evaluate forms that are not lambda expressions. */
+    if(!VM_EVAL_ARG_DONE(thread, 1) &&
+       ((argv[1].type == VM_TYPE_FORM &&
+         argv[1].value.form.type != VM_FORM_LAMBDA) ||
+        argv[1].type == VM_TYPE_SYMBOL)) {
+      /* Evaluate non-lambda forms and bare symbol references so that
+         (define y x) binds y to the value of x rather than to the
+         symbol x itself. Lambda forms self-evaluate and integers,
+         strings, etc. evaluate to themselves, so they need no extra
+         pass through the scheduler. */
       VM_EVAL_ARG(thread, 1);
       return;
     }

--- a/tests/unit-tests/vm-specific/test-define-symbol-value.scm
+++ b/tests/unit-tests/vm-specific/test-define-symbol-value.scm
@@ -1,0 +1,35 @@
+;; Regression: (define b a) where the value is a bare symbol referring
+;; to another binding used to bind b to the SYMBOL a rather than to its
+;; value. The fix lets the VM's define primitive evaluate symbol-typed
+;; arguments, not just non-lambda forms.
+
+(include "../unit-test-framework.scm")
+
+(test-suite "(define b a) with symbol value")
+
+;; Integer alias.
+(define src-int 42)
+(define ali-int src-int)
+(assert-equal 42 ali-int "(define ali-int src-int) propagates the integer")
+
+;; String alias (also exercises post-resolve string handling).
+(define src-str "hello")
+(define ali-str src-str)
+(assert-equal "hello" ali-str "(define ali-str src-str) propagates the string")
+
+;; List alias.
+(define src-lst '(1 2 3))
+(define ali-lst src-lst)
+(assert-equal '(1 2 3) ali-lst "(define ali-lst src-lst) propagates the list")
+
+;; Quoted symbol still binds to the symbol itself, not whatever foo is.
+(define foo 99)
+(define quoted-foo 'foo)
+(assert-equal 99 foo "Sanity: quoted-foo doesn't shadow foo")
+(assert-true (symbol? quoted-foo) "Quoted symbol stored as a symbol")
+
+;; Form value still works.
+(define result-of-form (+ 1 2))
+(assert-equal 3 result-of-form "Form value evaluates as before")
+
+(test-summary)


### PR DESCRIPTION
(define y x) used to bind y to the SYMBOL x rather than to whatever value x was holding. The define primitive only triggered argument evaluation for non-lambda forms; bare symbol references slipped past and got stored verbatim.

Fix: extend the eval-trigger condition to also cover VM_TYPE_SYMBOL arguments. Lambda forms keep self-evaluating, integers / strings / booleans evaluate to themselves, and now bare symbol references go through the scheduler's resolution path so define stores the referenced value.