### PR TITLE
Bound vm_write_object recursion depth and byte-buffer hex-dump width

### DIFF
--- a/core/vm-lang.c
+++ b/core/vm-lang.c
@@ -254,8 +254,15 @@ vm_return_from_function(vm_thread_t *thread, vm_obj_t *obj)
   vm_set_error_object(thread, obj);
 }
 
-void
-vm_write_object(vm_port_t *port, vm_obj_t *obj)
+/* Cap recursion through nested structures so that a cyclic list,
+   vector, or other self-referential value doesn't loop forever in
+   the printer. 16 levels of nesting is far more than any human-
+   readable output and is well within C-stack budget. Past the
+   limit we print "..." and stop recursing. */
+#define VM_WRITE_MAX_DEPTH 16
+
+static void
+write_object_depth(vm_port_t *port, vm_obj_t *obj, int depth)
 {
   static uint8_t nested_print;
   vm_thread_t *thread;
@@ -264,6 +271,11 @@ vm_write_object(vm_port_t *port, vm_obj_t *obj)
   vm_list_item_t *item;
   int i;
   vm_boolean_t output_raw;
+
+  if(depth >= VM_WRITE_MAX_DEPTH) {
+    vm_write(port, "...");
+    return;
+  }
 
   if(port != NULL && port->thread != NULL) {
     thread = port->thread;
@@ -318,7 +330,7 @@ vm_write_object(vm_port_t *port, vm_obj_t *obj)
          VM_IS_SET(obj->value.list->flags, VM_LIST_FLAG_PAIR)) {
         vm_write(port, ". ");
       }
-      vm_write_object(port, (vm_obj_t *)&item->obj);
+      write_object_depth(port, (vm_obj_t *)&item->obj, depth + 1);
       item = item->next;
 
       if(item != NULL) {
@@ -342,15 +354,23 @@ vm_write_object(vm_port_t *port, vm_obj_t *obj)
         vm_native_write_buffer(port, (const char *)obj->value.vector->bytes,
                                obj->value.vector->length);
       } else {
-        for(i = 0; i < obj->value.vector->length; i++) {
+        /* Cap the hex dump so a large buffer doesn't pin the
+           cooperative scheduler emitting millions of \xNN sequences. */
+        vm_integer_t len = obj->value.vector->length;
+        vm_integer_t limit = len < VM_BUFFER_PRINT_LIMIT
+                             ? len : VM_BUFFER_PRINT_LIMIT;
+        for(i = 0; i < limit; i++) {
 	  vm_write(port, "\\x%02x", obj->value.vector->bytes[i]);
+        }
+        if(len > limit) {
+          vm_write(port, "<%u bytes omitted>", (unsigned)(len - limit));
         }
       }
     } else {
       nested_print = 1;
       vm_write(port, "#(");
       for(i = 0; i < obj->value.vector->length; i++) {
-        vm_write_object(port, &obj->value.vector->elements[i]);
+        write_object_depth(port, &obj->value.vector->elements[i], depth + 1);
 
 	if(i < obj->value.vector->length - 1) {
 	  vm_write(port, " ");
@@ -396,6 +416,12 @@ vm_write_object(vm_port_t *port, vm_obj_t *obj)
   default:
     vm_write(port, "#<unknown>");
   }
+}
+
+void
+vm_write_object(vm_port_t *port, vm_obj_t *obj)
+{
+  write_object_depth(port, obj, 0);
 }
 
 int

--- a/ports/contiki-ng/vm-config.h
+++ b/ports/contiki-ng/vm-config.h
@@ -212,6 +212,10 @@
 #define VM_LIST_PRINT_LIMIT 10
 #endif
 
+#ifndef VM_BUFFER_PRINT_LIMIT
+#define VM_BUFFER_PRINT_LIMIT 64
+#endif
+
 /* Build an executable of the VM and an app stored
    as bytecode in a header file. */
 #ifndef VM_BUNDLE

--- a/ports/javascript/vm-config.h
+++ b/ports/javascript/vm-config.h
@@ -149,4 +149,8 @@
 #define VM_LIST_PRINT_LIMIT 10
 #endif
 
+#ifndef VM_BUFFER_PRINT_LIMIT
+#define VM_BUFFER_PRINT_LIMIT 64
+#endif
+
 #endif /* !VM_CONFIG_H */

--- a/ports/posix/vm-config.h
+++ b/ports/posix/vm-config.h
@@ -180,6 +180,10 @@
 #define VM_LIST_PRINT_LIMIT 10
 #endif
 
+#ifndef VM_BUFFER_PRINT_LIMIT
+#define VM_BUFFER_PRINT_LIMIT 64
+#endif
+
 /* Build an executable of the VM and an app stored
    as bytecode in a header file. */
 #ifndef VM_BUNDLE

--- a/tests/unit-tests/vm-specific/test-write-depth-bound.scm
+++ b/tests/unit-tests/vm-specific/test-write-depth-bound.scm
@@ -1,0 +1,44 @@
+;; Regression: vm_write_object had two unbounded loops -- recursion
+;; through nested lists/vectors/boxes (depth) and per-byte hex emission
+;; for byte-buffer vectors (width). Either could pin the cooperative
+;; scheduler indefinitely on hostile input. Both are now capped --
+;; recursion at 16 levels, byte-buffer hex dump at VM_BUFFER_PRINT_LIMIT
+;; bytes -- with an "<X items|bytes omitted>" tail.
+
+(include "../unit-test-framework.scm")
+
+(test-suite "vm_write_object hostile-input bounds")
+
+;; Build a vector nested DEPTH levels deep. Each level is a
+;; single-element vector wrapping the previous.
+(define (nest depth)
+  (define (build d acc)
+    (if (= d 0) acc (build (- d 1) (vector acc))))
+  (build depth 0))
+
+;; The smoke test is that printing a 30-level nested vector returns
+;; cleanly. Without the depth cap the printer would either spin (on a
+;; cyclic structure) or recurse 30 levels into itself; with the cap it
+;; emits "..." past 16 levels and unwinds. Reaching the next assertion
+;; demonstrates the call returned.
+(print (nest 30)) (print "\n")
+(assert-true #t "deep vector print returned cleanly")
+
+;; Shallow nesting (below the cap) round-trips through equal? as
+;; expected -- the cap doesn't kick in for normal-sized values.
+(define small (nest 3))
+(assert-equal small small "shallow vector compares equal to itself")
+
+;; A multi-kilobyte byte buffer would, without the width cap, emit
+;; megabytes of \xNN sequences in one scheduler tick. The smoke test
+;; is that printing a 5000-byte buffer returns cleanly. The buffer
+;; itself round-trips equal? to itself either way.
+(define big-buffer (make-buffer 5000))
+(define (fill i)
+  (if (= i 5000) 'done
+      (begin (buffer-append big-buffer i (modulo i 256)) (fill (+ i 1)))))
+(fill 0)
+(print big-buffer) (print "\n")
+(assert-true #t "wide buffer print returned cleanly")
+
+(test-summary)


### PR DESCRIPTION
Two unbounded loops in the printer could pin the cooperative scheduler on hostile input:

  - Recursion through nested lists, vectors, and (later) boxes had no cap. A self-referential structure or a sufficiently nested value would either spin forever or overflow the C stack.

  - The per-byte hex-dump for byte-buffer vectors iterated the full length, so a multi-megabyte buffer would emit megabytes of \xNN text in a single non-preemptible scheduler tick.

Both are now capped:

  - VM_WRITE_MAX_DEPTH = 16 levels of nesting; past the limit the printer emits "..." and unwinds.
  - VM_BUFFER_PRINT_LIMIT = 64 bytes for the console-side hex dump; past the limit the printer emits "<X bytes omitted>". Raw output via vm_native_write_buffer is left alone -- it goes through one syscall, isn't a printer-formatting concern, and a user writing binary to a non-console port wants the full payload.