### PR TITLE
contiki-ng: gate perfmon process behind VM_PERFMON_ENABLE (default off)

### DIFF
--- a/ports/contiki-ng/vm-config.h
+++ b/ports/contiki-ng/vm-config.h
@@ -69,6 +69,16 @@
 #define VM_PROFILER_ENABLE 0
 #endif
 
+/* Run the periodic performance-monitor process that emits VPM/SPM
+   lines (CPU, power, bandwidth, policy) every VM_PERF_MONITOR_INTERVAL
+   seconds. Off by default because the lines are noisy on the console
+   and aren't useful for most interactive sessions; enable when you
+   actually want the periodic stream of metrics. The same numbers
+   remain queryable on demand via vm-shell. */
+#ifndef VM_PERFMON_ENABLE
+#define VM_PERFMON_ENABLE 0
+#endif
+
 /* Emit periodic memory-pool utilisation lines from the performance monitor.
    Counters read are maintained on the hot path anyway, so the only cost is
    a few extra prints per monitor tick. */

--- a/ports/contiki-ng/vm.c
+++ b/ports/contiki-ng/vm.c
@@ -69,7 +69,9 @@ PROCESS_THREAD(vm_process, ev, data)
   vm_lib_register(&vm_lib_crypto);
   vm_lib_register(&vm_lib_sensors);
 
+#if VM_PERFMON_ENABLE
   process_start(&vm_perfmon_process, NULL);
+#endif
   serial_shell_init();
   vm_shell_init();
 


### PR DESCRIPTION
The performance monitor process emits VPM/SPM lines (CPU, power, bandwidth, policy) on the console every VM_PERF_MONITOR_INTERVAL seconds (5 by default). The lines are noisy and aren't useful for most sessions; the same numbers remain queryable on demand via vm-shell when wanted.

Adds VM_PERFMON_ENABLE to ports/contiki-ng/vm-config.h, default 0. process_start(&vm_perfmon_process, NULL) is now gated on it. To opt back in, define -DVM_PERFMON_ENABLE=1 at compile time.