### PR TITLE
sched: preserve evaluated argv across TCO collapse for direct lambda recursion

### DIFF
--- a/core/expr-primitives.c
+++ b/core/expr-primitives.c
@@ -695,6 +695,9 @@ VM_FUNCTION(apply)
   thread->expr->argc = 1 + list->length;
   thread->expr->eval_requested = 1;
   thread->expr->eval_completed = 0;
+  /* Tell cut_tail_call_frames to re-execute the call site so apply
+     re-runs and re-spreads, rather than preserve the rewritten argv. */
+  VM_SET_FLAG(thread->expr->flags, VM_EXPR_REWRITTEN_BY_APPLY);
 
   vm_list_destroy(list);
 }

--- a/core/vm-sched.c
+++ b/core/vm-sched.c
@@ -151,17 +151,32 @@ cut_tail_call_frames(vm_thread_t *thread)
         VM_FREE(saved_bindings);
       }
 
-      /* Reset execution state for tail-optimized frame. The merged frame
-         is about to re-execute its call-site bytecode from scratch; the
-         LAMBDA marker reflects the prior dispatch and must be cleared so
-         that init_lambda_execution can re-engage for direct calls and so
-         that primitive-headed call sites (e.g. apply) finish their
-         eval-arg processing instead of exiting the dispatch loop early. */
-      VM_CLEAR_FLAG(thread->expr->flags,
-                    VM_EXPR_HAVE_OBJECTS | VM_EXPR_LAMBDA);
-      thread->expr->eval_completed = 0;
-      thread->expr->eval_requested = 0;
-      thread->expr->ip = VM_TABLE_GET(thread->program->exprv, thread->expr->expr_id);
+      /* Apply needs the call site re-executed so it can re-run and
+         re-spread the args list. Direct lambda recursion preserves
+         argv because re-loading would silently double-fire
+         side-effecting argument expressions like (read-char). */
+      if(VM_IS_SET(thread->expr->flags, VM_EXPR_REWRITTEN_BY_APPLY)) {
+        VM_CLEAR_FLAG(thread->expr->flags,
+                      VM_EXPR_HAVE_OBJECTS | VM_EXPR_LAMBDA |
+                      VM_EXPR_REWRITTEN_BY_APPLY);
+        thread->expr->eval_completed = 0;
+        thread->expr->eval_requested = 0;
+        thread->expr->ip = VM_TABLE_GET(thread->program->exprv,
+                                        thread->expr->expr_id);
+      } else {
+        /* LAMBDA stays set so the (LAMBDA && all_completed) guard
+           suppresses vm_eval_expr after post-pop overwrites argv[0]
+           with the body's return value; without it the scheduler
+           would try to dispatch the result-as-operator. */
+        if(thread->expr->argc > 0) {
+          thread->expr->eval_completed =
+            ((1U << thread->expr->argc) - 1U) & ~1U;
+          thread->expr->eval_requested = (1U << thread->expr->argc) - 1U;
+        } else {
+          thread->expr->eval_completed = 0;
+          thread->expr->eval_requested = 0;
+        }
+      }
       return;
     }
   }

--- a/include/vm.h
+++ b/include/vm.h
@@ -112,6 +112,7 @@ typedef struct vm_program {
 #define VM_EXPR_SAVE_FRAME   0x10
 #define VM_EXPR_CONTINUATION 0x20
 #define VM_EXPR_GUARD_IN_HANDLER  0x40  /* Guard is executing handler, not body (R6RS/R7RS) */
+#define VM_EXPR_REWRITTEN_BY_APPLY 0x80 /* Apply did in-place argv rewrite; cut_tail_call_frames re-executes the call site instead of preserving argv */
 
 typedef uint32_t vm_arg_set_t;
 

--- a/tests/unit-tests/r5rs/test-tail-calls.scm
+++ b/tests/unit-tests/r5rs/test-tail-calls.scm
@@ -93,4 +93,28 @@
       (apply loop-apply (list (- n 1)))))
 (assert-equal 'ok (loop-apply TCO-DEPTH) "apply in tail position: 50k tail calls")
 
+(test-suite "Tail Recursion - Side-Effecting Argument Expressions")
+
+;; Regression: cut_tail_call_frames previously re-executed the call-site
+;; bytecode, double-firing side-effecting argument expressions on each
+;; tail call. See doc/apply-tail-call-investigation.md.
+
+(define se-counter 0)
+(define (next!)
+  (let ((v se-counter))
+    (set! se-counter (+ se-counter 1))
+    v))
+
+(define (loop-side-effect c limit)
+  (if (>= c limit)
+      'done
+      (loop-side-effect (next!) limit)))
+
+(set! se-counter 0)
+(assert-equal 'done (loop-side-effect (next!) 100)
+              "tail call with side-effecting arg: termination")
+;; 101 = one seed call + one per iteration; pre-fix advanced ~2x.
+(assert-equal 101 se-counter
+              "side-effecting arg evaluated exactly once per call")
+
 (test-summary)


### PR DESCRIPTION
cut_tail_call_frames cleared HAVE_OBJECTS, reset eval state, and rewound IP after every collapse so the merged frame re-executed its call-site bytecode. That assumes idempotent argument evaluation, which holds for variables and arithmetic but not for side-effecting args. A tail-recursive (read-char) loop dropped every other input character.

Apply still needs the re-execute model: its rewrite changes argv, but expr_id's bytecode is still `(apply f args)`. Branch on a new VM_EXPR_REWRITTEN_BY_APPLY flag set by apply after the rewrite, sticky across cuts via flag inheritance:

  * Apply path: existing re-execute behavior.
  * Direct path: preserve argv, mark args 1..argc-1 completed, clear bit 0 to dispatch the operator slot. LAMBDA stays set so the (LAMBDA && all_completed) guard at vm-sched.c:365 keeps vm_eval_expr from firing on the result-as-operator after post-pop.

Adds two regression assertions to test-tail-calls.scm. Apply tail call still works at 50000+ depth.