### PR TITLE
io: name the return values of vm_native_read*; tighten poll-failure path

### DIFF
--- a/core/expr-io.c
+++ b/core/expr-io.c
@@ -171,15 +171,16 @@ VM_FUNCTION(read_char)
   }
 
   r = vm_native_read_char(thread, port, &c);
-  if(r == 1) {
+  if(r == VM_NATIVE_READ_OK) {
     VM_PUSH_CHARACTER(c);
     VM_CLEAR_FLAG(thread->expr->flags, VM_EXPR_RESTART);
-  } else if(r == -1) {
+  } else if(r == VM_NATIVE_READ_EOF) {
     VM_PUSH_EOF();
     VM_CLEAR_FLAG(thread->expr->flags, VM_EXPR_RESTART);
-  } else if(thread->status == VM_THREAD_WAITING) {
+  } else if(r == VM_NATIVE_READ_BLOCKED) {
     VM_SET_FLAG(thread->expr->flags, VM_EXPR_RESTART);
   }
+  /* VM_NATIVE_READ_ERROR: vm_signal_error already issued. */
 }
 
 VM_FUNCTION(read)
@@ -193,13 +194,13 @@ VM_FUNCTION(read)
   }
 
   r = vm_native_read(thread, port, &thread->result);
-  if(r == -1) {
+  if(r == VM_NATIVE_READ_EOF) {
     VM_PUSH_EOF();
-  }
-
-  if(r != 1 && r != -1 && thread->status == VM_THREAD_WAITING) {
+    VM_CLEAR_FLAG(thread->expr->flags, VM_EXPR_RESTART);
+  } else if(r == VM_NATIVE_READ_BLOCKED) {
     VM_SET_FLAG(thread->expr->flags, VM_EXPR_RESTART);
   } else {
+    /* OK or ERROR: don't keep restarting; the result (or signal) is in. */
     VM_CLEAR_FLAG(thread->expr->flags, VM_EXPR_RESTART);
   }
 }
@@ -216,13 +217,13 @@ VM_FUNCTION(peek_char)
   }
 
   r = vm_native_peek_char(thread, port, &c);
-  if(r == 1) {
+  if(r == VM_NATIVE_READ_OK) {
     VM_PUSH_CHARACTER(c);
     VM_CLEAR_FLAG(thread->expr->flags, VM_EXPR_RESTART);
-  } else if(r == -1) {
+  } else if(r == VM_NATIVE_READ_EOF) {
     VM_PUSH_EOF();
     VM_CLEAR_FLAG(thread->expr->flags, VM_EXPR_RESTART);
-  } else if(thread->status == VM_THREAD_WAITING) {
+  } else if(r == VM_NATIVE_READ_BLOCKED) {
     VM_SET_FLAG(thread->expr->flags, VM_EXPR_RESTART);
   }
 }

--- a/include/vm-native.h
+++ b/include/vm-native.h
@@ -52,6 +52,16 @@ void vm_native_incoming_clientp(vm_thread_t *, vm_port_t *, vm_obj_t *);
 int vm_native_resolve(vm_thread_t *, const char *hostname);
 int vm_native_parse_address(const char *str, uint8_t *bytes, size_t *len);
 vm_port_t *vm_native_open_file(vm_thread_t *, const char *, int);
+/* Return values for vm_native_read, vm_native_read_char, and
+   vm_native_peek_char. ERROR means the impl already called
+   vm_signal_error; the caller does not need to check thread->status. */
+typedef enum {
+  VM_NATIVE_READ_OK      =  1,
+  VM_NATIVE_READ_BLOCKED =  0,
+  VM_NATIVE_READ_EOF     = -1,
+  VM_NATIVE_READ_ERROR   = -2
+} vm_native_read_result_t;
+
 int vm_native_read(vm_thread_t *, vm_port_t *, vm_obj_t *);
 int vm_native_read_char(vm_thread_t *, vm_port_t *, vm_character_t *);
 int vm_native_peek_char(vm_thread_t *, vm_port_t *, vm_character_t *);

--- a/ports/contiki-ng/vm-native.c
+++ b/ports/contiki-ng/vm-native.c
@@ -1134,9 +1134,11 @@ vm_native_read(vm_thread_t *thread, vm_port_t *port, vm_obj_t *obj)
   int r;
 
   if(VM_IS_SET(port->flags, VM_PORT_FLAG_EOF)) {
-    return -1;
+    return VM_NATIVE_READ_EOF;
   }
 
+  /* The io->read_object callback's own return convention: >=1 bytes
+     read, 0 EOF, <0 I/O error. -2 stands in for "no read callback". */
   if(port->io && port->io->read_object) {
     r = port->io->read_object(port, obj);
   } else {
@@ -1144,17 +1146,15 @@ vm_native_read(vm_thread_t *thread, vm_port_t *port, vm_obj_t *obj)
   }
 
   if(r >= 1) {
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
   if(r == 0) {
-    /* End of stream. */
     port->flags |= VM_PORT_FLAG_EOF;
-    return -1;
+    return VM_NATIVE_READ_EOF;
   }
-  /* r < 0: real I/O error. */
   vm_signal_error(thread, VM_ERROR_IO);
   vm_set_error_string(thread, "port read failed");
-  return 0;
+  return VM_NATIVE_READ_ERROR;
 }
 
 int
@@ -1166,11 +1166,11 @@ vm_native_read_char(vm_thread_t *thread, vm_port_t *port, vm_character_t *c)
   if(port->has_peek) {
     *c = port->peek_char;
     port->has_peek = 0;
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
 
   if(VM_IS_SET(port->flags, VM_PORT_FLAG_EOF)) {
-    return -1;
+    return VM_NATIVE_READ_EOF;
   }
 
   if(port->io && port->io->read) {
@@ -1181,15 +1181,15 @@ vm_native_read_char(vm_thread_t *thread, vm_port_t *port, vm_character_t *c)
 
   if(r >= 1) {
     *c = buf[0];
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
   if(r == 0) {
     port->flags |= VM_PORT_FLAG_EOF;
-    return -1;
+    return VM_NATIVE_READ_EOF;
   }
   vm_signal_error(thread, VM_ERROR_IO);
   vm_set_error_string(thread, "port read failed");
-  return 0;
+  return VM_NATIVE_READ_ERROR;
 }
 
 int
@@ -1199,15 +1199,15 @@ vm_native_peek_char(vm_thread_t *thread, vm_port_t *port, vm_character_t *c)
 
   if(port->has_peek) {
     *c = port->peek_char;
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
   r = vm_native_read_char(thread, port, c);
-  if(r != 1) {
+  if(r != VM_NATIVE_READ_OK) {
     return r;
   }
   port->peek_char = *c;
   port->has_peek = 1;
-  return 1;
+  return VM_NATIVE_READ_OK;
 }
 
 vm_boolean_t

--- a/ports/javascript/vm-native.c
+++ b/ports/javascript/vm-native.c
@@ -793,12 +793,12 @@ vm_native_read(vm_thread_t *thread, vm_port_t *port, vm_obj_t *obj)
   vm_vector_t *vector;
 
   if(VM_IS_SET(port->flags, VM_PORT_FLAG_EOF)) {
-    return -1;
+    return VM_NATIVE_READ_EOF;
   }
 
   if(port->io == NULL || port->io->read == NULL) {
     vm_signal_error(thread, VM_ERROR_IO);
-    return 0;
+    return VM_NATIVE_READ_ERROR;
   }
 
   if(port_is_ready(port->fd, 0)) {
@@ -808,29 +808,30 @@ vm_native_read(vm_thread_t *thread, vm_port_t *port, vm_obj_t *obj)
     if(len < 0) {
       vm_signal_error(thread, VM_ERROR_IO);
       vm_set_error_string(thread, strerror(errno));
-      return 0;
+      return VM_NATIVE_READ_ERROR;
     } else if(len == 0) {
       VM_SET_FLAG(port->flags, VM_PORT_FLAG_EOF);
-      return -1;
+      return VM_NATIVE_READ_EOF;
     }
 
     vector = vm_vector_create(obj, len, VM_VECTOR_FLAG_BUFFER) ;
     if(vector == NULL) {
       vm_signal_error(thread, VM_ERROR_HEAP);
-      return 0;
+      return VM_NATIVE_READ_ERROR;
     }
 
     memcpy(vector->bytes, buf, len);
-    return 1;
-  } else {
-    if(vm_posix_poll_port(thread, port->fd, 0) == 0) {
-      VM_DEBUG(VM_DEBUG_MEDIUM, "native: failed to poll fd %d", port->fd);
-      return 0;
-    }
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
 
-  return 0;
+  if(vm_posix_poll_port(thread, port->fd, 0) == 0) {
+    /* Poll table full -- treat as an I/O error; the read couldn't be
+       parked and there is nothing the caller can usefully retry. */
+    VM_DEBUG(VM_DEBUG_MEDIUM, "native: failed to poll fd %d", port->fd);
+    vm_signal_error(thread, VM_ERROR_IO);
+    return VM_NATIVE_READ_ERROR;
+  }
+  return VM_NATIVE_READ_BLOCKED;
 }
 
 int
@@ -842,16 +843,16 @@ vm_native_read_char(vm_thread_t *thread, vm_port_t *port, vm_character_t *c)
   if(port->has_peek) {
     *c = port->peek_char;
     port->has_peek = 0;
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
 
   if(VM_IS_SET(port->flags, VM_PORT_FLAG_EOF)) {
-    return -1;
+    return VM_NATIVE_READ_EOF;
   }
 
   if(port->io == NULL || port->io->read == NULL) {
     vm_signal_error(thread, VM_ERROR_IO);
-    return 0;
+    return VM_NATIVE_READ_ERROR;
   }
 
   if(port_is_ready(port->fd, 0)) {
@@ -860,22 +861,22 @@ vm_native_read_char(vm_thread_t *thread, vm_port_t *port, vm_character_t *c)
     if(r < 0) {
       vm_signal_error(thread, VM_ERROR_IO);
       vm_set_error_string(thread, strerror(errno));
-      return 0;
+      return VM_NATIVE_READ_ERROR;
     } else if(r == 0) {
       VM_SET_FLAG(port->flags, VM_PORT_FLAG_EOF);
-      return -1;
+      return VM_NATIVE_READ_EOF;
     }
 
     *c = buf[0];
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
 
   if(vm_posix_poll_port(thread, port->fd, 0) == 0) {
     VM_DEBUG(VM_DEBUG_MEDIUM, "native: failed to poll fd %d", port->fd);
-    return 0;
+    vm_signal_error(thread, VM_ERROR_IO);
+    return VM_NATIVE_READ_ERROR;
   }
-
-  return 0;
+  return VM_NATIVE_READ_BLOCKED;
 }
 
 int
@@ -885,15 +886,15 @@ vm_native_peek_char(vm_thread_t *thread, vm_port_t *port, vm_character_t *c)
 
   if(port->has_peek) {
     *c = port->peek_char;
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
   r = vm_native_read_char(thread, port, c);
-  if(r != 1) {
+  if(r != VM_NATIVE_READ_OK) {
     return r;
   }
   port->peek_char = *c;
   port->has_peek = 1;
-  return 1;
+  return VM_NATIVE_READ_OK;
 }
 
 vm_boolean_t

--- a/ports/posix/vm-native.c
+++ b/ports/posix/vm-native.c
@@ -805,12 +805,12 @@ vm_native_read(vm_thread_t *thread, vm_port_t *port, vm_obj_t *obj)
   vm_vector_t *vector;
 
   if(VM_IS_SET(port->flags, VM_PORT_FLAG_EOF)) {
-    return -1;
+    return VM_NATIVE_READ_EOF;
   }
 
   if(port->io == NULL || port->io->read == NULL) {
     vm_signal_error(thread, VM_ERROR_IO);
-    return 0;
+    return VM_NATIVE_READ_ERROR;
   }
 
   if(port_is_ready(port->fd, 0)) {
@@ -820,29 +820,30 @@ vm_native_read(vm_thread_t *thread, vm_port_t *port, vm_obj_t *obj)
     if(len < 0) {
       vm_signal_error(thread, VM_ERROR_IO);
       vm_set_error_string(thread, strerror(errno));
-      return 0;
+      return VM_NATIVE_READ_ERROR;
     } else if(len == 0) {
       VM_SET_FLAG(port->flags, VM_PORT_FLAG_EOF);
-      return -1;
+      return VM_NATIVE_READ_EOF;
     }
 
     vector = vm_vector_create(obj, len, VM_VECTOR_FLAG_BUFFER) ;
     if(vector == NULL) {
       vm_signal_error(thread, VM_ERROR_HEAP);
-      return 0;
+      return VM_NATIVE_READ_ERROR;
     }
 
     memcpy(vector->bytes, buf, len);
-    return 1;
-  } else {
-    if(vm_posix_poll_port(thread, port->fd, 0) == 0) {
-      VM_DEBUG(VM_DEBUG_MEDIUM, "native: failed to poll fd %d", port->fd);
-      return 0;
-    }
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
 
-  return 0;
+  if(vm_posix_poll_port(thread, port->fd, 0) == 0) {
+    /* Poll table full -- treat as an I/O error; the read couldn't be
+       parked and there is nothing the caller can usefully retry. */
+    VM_DEBUG(VM_DEBUG_MEDIUM, "native: failed to poll fd %d", port->fd);
+    vm_signal_error(thread, VM_ERROR_IO);
+    return VM_NATIVE_READ_ERROR;
+  }
+  return VM_NATIVE_READ_BLOCKED;
 }
 
 int
@@ -854,16 +855,16 @@ vm_native_read_char(vm_thread_t *thread, vm_port_t *port, vm_character_t *c)
   if(port->has_peek) {
     *c = port->peek_char;
     port->has_peek = 0;
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
 
   if(VM_IS_SET(port->flags, VM_PORT_FLAG_EOF)) {
-    return -1;
+    return VM_NATIVE_READ_EOF;
   }
 
   if(port->io == NULL || port->io->read == NULL) {
     vm_signal_error(thread, VM_ERROR_IO);
-    return 0;
+    return VM_NATIVE_READ_ERROR;
   }
 
   if(port_is_ready(port->fd, 0)) {
@@ -872,22 +873,22 @@ vm_native_read_char(vm_thread_t *thread, vm_port_t *port, vm_character_t *c)
     if(r < 0) {
       vm_signal_error(thread, VM_ERROR_IO);
       vm_set_error_string(thread, strerror(errno));
-      return 0;
+      return VM_NATIVE_READ_ERROR;
     } else if(r == 0) {
       VM_SET_FLAG(port->flags, VM_PORT_FLAG_EOF);
-      return -1;
+      return VM_NATIVE_READ_EOF;
     }
 
     *c = buf[0];
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
 
   if(vm_posix_poll_port(thread, port->fd, 0) == 0) {
     VM_DEBUG(VM_DEBUG_MEDIUM, "native: failed to poll fd %d", port->fd);
-    return 0;
+    vm_signal_error(thread, VM_ERROR_IO);
+    return VM_NATIVE_READ_ERROR;
   }
-
-  return 0;
+  return VM_NATIVE_READ_BLOCKED;
 }
 
 int
@@ -897,15 +898,15 @@ vm_native_peek_char(vm_thread_t *thread, vm_port_t *port, vm_character_t *c)
 
   if(port->has_peek) {
     *c = port->peek_char;
-    return 1;
+    return VM_NATIVE_READ_OK;
   }
   r = vm_native_read_char(thread, port, c);
-  if(r != 1) {
+  if(r != VM_NATIVE_READ_OK) {
     return r;
   }
   port->peek_char = *c;
   port->has_peek = 1;
-  return 1;
+  return VM_NATIVE_READ_OK;
 }
 
 vm_boolean_t


### PR DESCRIPTION
vm_native_read, vm_native_read_char, and vm_native_peek_char returned 1, 0, and -1 with no named constants. The 0 case was overloaded: either the thread was parked (caller should set EXPR_RESTART) or vm_signal_error was called inside the impl (caller should not). The expr-io.c handlers disambiguated by checking thread->status, which is brittle and easy to get wrong.

Add vm_native_read_result_t with named values:

  * VM_NATIVE_READ_OK      =  1   data in *c / *obj
  * VM_NATIVE_READ_BLOCKED =  0   thread parked, retry via RESTART
  * VM_NATIVE_READ_EOF     = -1   sticky via VM_PORT_FLAG_EOF
  * VM_NATIVE_READ_ERROR   = -2   vm_signal_error already called