### PR TITLE
io: surface write errors on stdio by falling back to vm_current_thread

### DIFF
--- a/ports/contiki-ng/vm-native.c
+++ b/ports/contiki-ng/vm-native.c
@@ -1279,17 +1279,21 @@ vm_native_write_buffer(vm_port_t *port, const char *buf, size_t len)
   }
 #endif
 
-  if(port->thread != NULL) {
-    if(ret < 0) {
-      vm_signal_error(port->thread, VM_ERROR_IO);
-      vm_set_error_string(port->thread, "port write failed");
-    } else if(port != NULL && VM_IS_SET(port->flags, VM_PORT_FLAG_SOCKET)) {
-      sock = port->opaque_desc;
-      attribute_bandwidth(port->thread, len);
-      vm_policy_check_bandwidth(port->thread);
-      attribute_communication(port->thread, sock->proto,
-                              VM_MIN(uip_ntohs(sock->lport), uip_ntohs(sock->rport)));
-    }
+  if(ret < 0) {
+    /* Errors must reach the caller even when port->thread is NULL
+       (default stdio singletons). Bandwidth attribution below stays
+       gated on port->thread because socket "owner" is the right
+       attribution target there. */
+    vm_thread_t *t = port->thread != NULL ? port->thread : vm_current_thread();
+    vm_signal_error(t, VM_ERROR_IO);
+    vm_set_error_string(t, "port write failed");
+  } else if(port->thread != NULL && port != NULL &&
+            VM_IS_SET(port->flags, VM_PORT_FLAG_SOCKET)) {
+    sock = port->opaque_desc;
+    attribute_bandwidth(port->thread, len);
+    vm_policy_check_bandwidth(port->thread);
+    attribute_communication(port->thread, sock->proto,
+                            VM_MIN(uip_ntohs(sock->lport), uip_ntohs(sock->rport)));
   }
 
   return ret;

--- a/ports/javascript/vm-native.c
+++ b/ports/javascript/vm-native.c
@@ -983,8 +983,10 @@ vm_native_write(vm_port_t *port, const char *format, ...)
   }
 
   if(ret < 0) {
-    vm_signal_error(port->thread, VM_ERROR_IO);
-    vm_set_error_string(port->thread, strerror(errno));
+    /* port->thread is NULL on stdio singletons; fall back to caller. */
+    vm_thread_t *t = port->thread != NULL ? port->thread : vm_current_thread();
+    vm_signal_error(t, VM_ERROR_IO);
+    vm_set_error_string(t, strerror(errno));
   }
 
   return ret;
@@ -1008,9 +1010,10 @@ vm_native_write_buffer(vm_port_t *port, const char *buf, size_t len)
   }
 
   if(ret < (int)len) {
-    vm_signal_error(port->thread, VM_ERROR_IO);
+    vm_thread_t *t = port->thread != NULL ? port->thread : vm_current_thread();
+    vm_signal_error(t, VM_ERROR_IO);
     if(ret < 0) {
-      vm_set_error_string(port->thread, strerror(errno));
+      vm_set_error_string(t, strerror(errno));
     }
   }
 

--- a/ports/posix/vm-native.c
+++ b/ports/posix/vm-native.c
@@ -1032,8 +1032,12 @@ vm_native_write(vm_port_t *port, const char *format, ...)
 #endif
 
   if(ret < 0) {
-    vm_signal_error(port->thread, VM_ERROR_IO);
-    vm_set_error_string(port->thread, strerror(errno));
+    /* port->thread is NULL on the static stdin/stdout singletons, so
+       fall back to the calling thread to keep stdio write errors
+       from silently dropping. */
+    vm_thread_t *t = port->thread != NULL ? port->thread : vm_current_thread();
+    vm_signal_error(t, VM_ERROR_IO);
+    vm_set_error_string(t, strerror(errno));
   }
 
   return ret;
@@ -1070,9 +1074,10 @@ vm_native_write_buffer(vm_port_t *port, const char *buf, size_t len)
 #endif
 
   if(ret < (int)len) {
-    vm_signal_error(port->thread, VM_ERROR_IO);
+    vm_thread_t *t = port->thread != NULL ? port->thread : vm_current_thread();
+    vm_signal_error(t, VM_ERROR_IO);
     if(ret < 0) {
-      vm_set_error_string(port->thread, strerror(errno));
+      vm_set_error_string(t, strerror(errno));
     }
   }
 


### PR DESCRIPTION
vm_native_write and vm_native_write_buffer in all three ports reported errors via vm_signal_error(port->thread, ...). The static stdin/stdout singletons have port->thread = NULL, so writes that failed (e.g. EPIPE on a closed pipe) silently dropped the error -- vm_signal_error with a NULL thread is a no-op.

Fix: fall back to vm_current_thread() when port->thread is NULL, matching the pattern at core/vm-lang.c:272-276. For Contiki-NG, the original `if(port->thread != NULL)` guard also wrapped socket bandwidth attribution; restructure so error reporting always runs and bandwidth attribution stays gated on port->thread (the socket owner is the right attribution target there).