### PR TITLE
list: make append, remove, and vm_list_copy non-destructive

### DIFF
--- a/core/expr-list.c
+++ b/core/expr-list.c
@@ -504,8 +504,12 @@ VM_FUNCTION(append)
     return;
   }
 
-  /* Continue the APPEND operation. */
-  list = vm_list_cdr(list, 0);
+  /* Continue the APPEND operation. The cdr must be non-destructive
+     (copy = 1) -- a destructive cdr here would shrink and free items
+     out of argv[1], which is the user's second-argument list. R5RS
+     specifies that append allocates a new list and shares structure
+     only with its last argument. */
+  list = vm_list_cdr(list, 1);
   if(list == NULL) {
     vm_signal_error(thread, VM_ERROR_HEAP);
   } else {
@@ -517,8 +521,8 @@ VM_FUNCTION(append)
 
 VM_FUNCTION(remove)
 {
-  vm_list_t *list;
-  vm_list_item_t *prev_item;
+  vm_list_t *src_list;
+  vm_list_t *new_list;
   vm_list_item_t *item;
 
   if(argv[1].type != VM_TYPE_LIST) {
@@ -526,35 +530,34 @@ VM_FUNCTION(remove)
     return;
   }
 
-  list = argv[1].value.list;
+  src_list = argv[1].value.list;
 
-  prev_item = NULL;
-  item = list->head;
-  while(item != NULL) {
-    if(vm_objects_deep_equal(thread, &item->obj, &argv[0])) {
-      list->length--;
+  /* Build a fresh list of elements that don't match argv[0]. R5RS /
+     SRFI-1 specify remove as non-destructive; the previous in-place
+     mutation corrupted any other reference to the same list (notably
+     quoted-list constants, which the compiler reuses across uses). */
+  vm_gc_disable();
 
-      if(item != list->head && item != list->tail) {
-        prev_item->next = item->next;
-      } else {
-        if(item == list->tail) {
-          list->tail = prev_item;
-          if(prev_item != NULL) {
-            prev_item->next = NULL;
-          }
-        }
-        if(item == list->head) {
-          list->head = item->next;
-        }
-      }
-    }
-
-    prev_item = item;
-    item = item->next;
+  new_list = vm_list_create();
+  if(new_list == NULL) {
+    vm_gc_enable();
+    vm_signal_error(thread, VM_ERROR_HEAP);
+    return;
   }
 
-  /* Return the modified list */
-  VM_PUSH_LIST(list);
+  for(item = src_list->head; item != NULL; item = item->next) {
+    if(!vm_objects_deep_equal(thread, &item->obj, &argv[0])) {
+      if(!vm_list_insert_tail(new_list, &item->obj)) {
+        vm_gc_enable();
+        vm_signal_error(thread, VM_ERROR_HEAP);
+        return;
+      }
+    }
+  }
+
+  vm_gc_enable();
+
+  VM_PUSH_LIST(new_list);
 }
 
 VM_FUNCTION(reverse)

--- a/core/vm-list.c
+++ b/core/vm-list.c
@@ -75,13 +75,31 @@ vm_list_t *
 vm_list_copy(vm_list_t *list)
 {
   vm_list_t *copy;
+  vm_list_item_t *src;
 
-  /* Disable GC during allocation to prevent premature collection */
+  /* Disable GC so the partially-built copy and its in-flight items
+     aren't reclaimed before the result is stored. */
   vm_gc_disable();
 
   copy = vm_list_create();
   if(copy != NULL) {
-    memcpy(copy, list, sizeof(vm_list_t));
+    /* Walk the source and allocate fresh item cells for the copy. A
+       shallow memcpy of the vm_list_t header (the previous behaviour)
+       leaves copy->head and copy->tail pointing at the source's
+       items, so any subsequent vm_list_insert_tail / vm_list_cdr that
+       mutates "the copy" silently mutates the source list too. */
+    for(src = list->head; src != NULL; src = src->next) {
+      if(!vm_list_insert_tail(copy, &src->obj)) {
+        vm_gc_enable();
+        return NULL;
+      }
+    }
+    /* Inherit the PAIR flag (improper-list marker) from the source so
+       the copy reports the same shape under list?/pair?. ORIGINAL is
+       set by vm_list_create. */
+    if(VM_IS_SET(list->flags, VM_LIST_FLAG_PAIR)) {
+      VM_SET_FLAG(copy->flags, VM_LIST_FLAG_PAIR);
+    }
   }
 
   vm_gc_enable();

--- a/tests/unit-tests/vm-specific/test-list-non-destructive.scm
+++ b/tests/unit-tests/vm-specific/test-list-non-destructive.scm
@@ -1,0 +1,79 @@
+;; VeloxVM Unit Tests - Non-destructive list primitives
+;;
+;; Regression coverage for a pre-existing bug in append, remove, and
+;; vm_list_copy where the operations mutated their input arguments in
+;; place. R5RS specifies that append must allocate a new list (sharing
+;; structure only with its last argument), and SRFI-1 / common
+;; convention require remove to leave its input unchanged. Sharing of
+;; list literals across use sites in compiled code makes the bug
+;; observable even when callers don't hold their own alias.
+
+(include "../unit-test-framework.scm")
+
+(test-suite "Non-destructive list primitives")
+
+;; ============================================================================
+;; append leaves both inputs untouched
+;; ============================================================================
+
+(define a-orig '(1 2 3))
+(define b-orig '(4 5 6))
+(define ab (append a-orig b-orig))
+
+(assert-equal '(1 2 3 4 5 6) ab "append produces the concatenation")
+(assert-equal '(1 2 3) a-orig  "first argument to append is unmodified")
+(assert-equal '(4 5 6) b-orig  "second argument to append is unmodified")
+(assert-false (eq? a-orig ab)  "append result is a new list (not eq? to first arg)")
+
+;; Repeated calls on the same literal each return a fresh result with
+;; the literal preserved.
+(define repeat-a '(1 2))
+(define r1 (append repeat-a '(3)))
+(define r2 (append repeat-a '(4)))
+(assert-equal '(1 2 3) r1 "first append result correct")
+(assert-equal '(1 2 4) r2 "second append result correct")
+(assert-equal '(1 2)   repeat-a "literal stays intact across multiple appends")
+
+;; ============================================================================
+;; remove leaves the input untouched
+;; ============================================================================
+
+(define rm-orig '(1 2 3 2 4))
+(define rm-result (remove 2 rm-orig))
+
+(assert-equal '(1 3 4)     rm-result "remove drops every match")
+(assert-equal '(1 2 3 2 4) rm-orig   "remove leaves the input list unchanged")
+(assert-false (eq? rm-orig rm-result) "remove result is a new list")
+
+;; Removing a non-existent element returns a list equal to the input
+;; but still freshly allocated.
+(define rm-noop (remove 99 rm-orig))
+(assert-equal '(1 2 3 2 4) rm-noop "remove of absent element preserves elements")
+(assert-equal '(1 2 3 2 4) rm-orig "input still unchanged after no-op remove")
+
+;; ============================================================================
+;; cons doesn't share structure that callers can mutate
+;; (cons internally calls vm_list_copy on its tail; a shallow copy
+;;  would let push/insert through the cons result corrupt the tail)
+;; ============================================================================
+
+(define cons-tail '(2 3))
+(define cons-result (cons 1 cons-tail))
+(assert-equal '(1 2 3) cons-result "cons constructs the expected list")
+(assert-equal '(2 3)   cons-tail   "cons leaves its tail argument intact")
+
+;; ============================================================================
+;; Multiple operations chained on the same literal
+;; ============================================================================
+
+(define base '(10 20 30))
+(define after-append (append base '(40)))
+(define after-remove (remove 20 base))
+(define after-cons   (cons 0 base))
+
+(assert-equal '(10 20 30 40) after-append "chained append")
+(assert-equal '(10 30)       after-remove "chained remove")
+(assert-equal '(0 10 20 30)  after-cons   "chained cons")
+(assert-equal '(10 20 30)    base         "literal preserved through three operations")
+
+(test-summary)


### PR DESCRIPTION
Three places mutated their input lists in violation of R5RS:

  1. vm_list_copy did a shallow memcpy of the vm_list_t header. The result shared head/tail pointers (and the entire item chain) with the source, so any subsequent vm_list_insert_tail / vm_list_cdr applied to "the copy" silently mutated the source list too. cons and the initial step of append both rely on vm_list_copy.

  2. append called vm_list_cdr(list, 0) on its second argument. The destructive cdr path shrinks the list and vm_free()s the discarded head item, which mutates the second argument out from under the caller. R5RS specifies that append allocates a new list and shares structure only with its last argument.

  3. remove walked the input list and rewrote next/head/tail pointers in place, returning the same list with matching items spliced out. SRFI-1 / common convention require remove to leave its input unchanged.

Fixes:
  * vm_list_copy walks the source and allocates fresh item cells via vm_list_insert_tail, inheriting the PAIR flag (improper-list marker) from the source.
  * append switches to vm_list_cdr(list, 1) (non-destructive cdr that returns a new list header sharing items).
  * remove builds a new list of non-matching elements rather than rewriting the input.

The bug was previously masked by the compiler emitting a fresh (list 'a 'b 'c) call at every (quote (a b c)) site, so each occurrence of a literal was its own allocation. It blocked planned compiler-side quote-lifting work, which depends on safe sharing of literal lists across use sites.

Adds tests/unit-tests/vm-specific/test-list-non-destructive.scm with regression coverage for append, remove, cons, and chained operations on a single literal.