### PR TITLE
Optimizer extensions the Racket compiler

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -2,10 +2,12 @@
 
 # Purpose: Compilation script for Velox applications.
 #
-# Usage: ./compile.sh [-f|--force] [<path>]
+# Usage: ./compile.sh [-f|--force] [--opt-stats] [--trace-opts] [<path>]
 #
 # Options:
 #   -f, --force     Force recompilation even if files are up-to-date
+#   --opt-stats     Print per-bucket optimization fire counts (Racket compiler)
+#   --trace-opts    Trace each optimization rewrite to stderr (Racket compiler)
 #
 # When no path is supplied, this script builds all available apps, tests, and benchmarks.
 #
@@ -116,7 +118,7 @@ compile_scheme () {
     OUTPUT_FILE="${BIN_DIR}/${BASENAME}.vm"
     mkdir -p "$BIN_DIR"
 
-    racket "$RACKET_COMPILER" -o "$OUTPUT_FILE" "$source_file" 2>&1 | grep -v "^Compiling\|^Compilation successful"
+    racket "$RACKET_COMPILER" $RACKET_FLAGS -o "$OUTPUT_FILE" "$source_file" 2>&1 | grep -v "^Compiling\|^Compilation successful"
     if [ ${PIPESTATUS[0]} -ne 0 ]; then
       ERRORS=$((ERRORS + 1))
     fi
@@ -332,15 +334,21 @@ find_source_file() {
 }
 
 # Parse command-line arguments
+RACKET_FLAGS=""
 while [[ $# -gt 0 ]]; do
   case $1 in
     -f|--force)
       FORCE_COMPILE=1
       shift
       ;;
+    --opt-stats|--trace-opts)
+      # Forward optimizer-diagnostic flags to the Racket compiler.
+      RACKET_FLAGS="$RACKET_FLAGS $1"
+      shift
+      ;;
     -*)
       echo "Unknown option: $1"
-      echo "Usage: ./compile.sh [-f|--force] [<path>]"
+      echo "Usage: ./compile.sh [-f|--force] [--opt-stats] [--trace-opts] [<path>]"
       exit 1
       ;;
     *)

--- a/languages/scheme-racket/dead-define.rkt
+++ b/languages/scheme-racket/dead-define.rkt
@@ -143,7 +143,11 @@
                [(and n (hash-ref dead-set n #f))
                 (let ([val (define-value e)])
                   (cond
-                    [(or (not val) (pure? val)) '()]
-                    [else (list val)]))]
+                    [(or (not val) (pure? val))
+                     (opt-note-fire! 'dead-define e '())
+                     '()]
+                    [else
+                     (opt-note-fire! 'dead-define-keep-val e val)
+                     (list val)]))]
                [else (list e)])))
          exprs)))

--- a/languages/scheme-racket/dead-define.rkt
+++ b/languages/scheme-racket/dead-define.rkt
@@ -1,0 +1,149 @@
+#lang racket
+
+;; VeloxVM Racket Compiler - Dead Top-Level Define Elimination
+;; Copyright (c) 2025, RISE Research Institutes of Sweden AB
+;;
+;; Removes top-level (define NAME VAL) forms whose NAME is never
+;; referenced anywhere else in the program. When VAL is pure the
+;; whole define vanishes; when it has side effects the value is
+;; kept as a bare top-level expression so the effects still happen.
+;;
+;; Iterates to fixpoint so transitively-dead defines (a helper used
+;; only by another dead define) all get reaped together. Variables
+;; introduced by surrounding lambdas (formal parameters) shadow the
+;; outer scope, so a top-level (define x ...) isn't kept alive by
+;; (define (f x) ...) just because f's body mentions x.
+
+(require "optimizer.rkt")   ; for pure?
+(provide eliminate-dead-defines)
+
+(define (eliminate-dead-defines exprs)
+  (let loop ([es exprs])
+    (let* ([defined (collect-defined-names es)]
+           [refs (collect-references es)]
+           [dead (filter (lambda (n) (not (hash-ref refs n #f))) defined)])
+      (cond
+        [(null? dead) es]
+        [else
+         (let* ([dead-set (names->set dead)]
+                [next (rewrite-dropping es dead-set)])
+           (if (equal? next es)
+               es
+               (loop next)))]))))
+
+;; ---------------------------------------------------------------------------
+;; Definitions
+
+;; Return the name a top-level define binds, or #f if `expr` isn't a
+;; (define ...) form we recognise.
+(define (define-name expr)
+  (and (pair? expr)
+       (eq? (car expr) 'define)
+       (>= (length expr) 2)
+       (let ([target (cadr expr)])
+         (cond
+           [(symbol? target) target]
+           [(pair? target) (car target)]
+           [else #f]))))
+
+;; Return a representative value expression for a define, synthesising
+;; a (lambda ...) for the function-shorthand. Used solely as the input
+;; to pure? when deciding whether the body must be preserved as a
+;; side-effecting top-level expression after the define is dropped.
+(define (define-value expr)
+  (cond
+    [(and (pair? expr)
+          (eq? (car expr) 'define)
+          (= (length expr) 3)
+          (symbol? (cadr expr)))
+     (caddr expr)]
+    [(and (pair? expr)
+          (eq? (car expr) 'define)
+          (>= (length expr) 3)
+          (pair? (cadr expr)))
+     `(lambda ,(cdr (cadr expr)) ,@(cddr expr))]
+    [else #f]))
+
+(define (collect-defined-names exprs)
+  (filter values (map define-name exprs)))
+
+(define (names->set names)
+  (let ([h (make-hash)])
+    (for ([n (in-list names)])
+      (hash-set! h n #t))
+    h))
+
+;; ---------------------------------------------------------------------------
+;; Reference collection
+
+;; Flatten a lambda formal-parameter spec (proper, dotted, or bare
+;; symbol) into a plain list. Used for shadow tracking.
+(define (formals->list formals)
+  (cond
+    [(null? formals) '()]
+    [(symbol? formals) (list formals)]
+    [(pair? formals) (cons (car formals) (formals->list (cdr formals)))]
+    [else '()]))
+
+;; Walk every top-level expression and record every symbol that
+;; appears in a reference position -- anywhere except a binding
+;; position (lambda formal, define LHS) or inside a quote. set!
+;; targets count as references: dropping the binding would break the
+;; assignment.
+(define (collect-references exprs)
+  (let ([refs (make-hash)])
+    (for-each (lambda (e) (walk-refs e refs '())) exprs)
+    refs))
+
+(define (walk-refs expr refs shadowed)
+  (cond
+    [(symbol? expr)
+     (unless (member expr shadowed)
+       (hash-set! refs expr #t))]
+    [(not (pair? expr)) (void)]
+    [(eq? (car expr) 'quote) (void)]
+    [(and (eq? (car expr) 'lambda) (>= (length expr) 3))
+     (let ([formals (formals->list (cadr expr))])
+       (for-each (lambda (e) (walk-refs e refs (append formals shadowed)))
+                 (cddr expr)))]
+    [(and (eq? (car expr) 'define) (>= (length expr) 3))
+     (let ([target (cadr expr)])
+       (cond
+         [(pair? target)
+          ;; function shorthand: formals shadow the body's name lookups.
+          (let ([params (formals->list (cdr target))])
+            (for-each (lambda (e) (walk-refs e refs (append params shadowed)))
+                      (cddr expr)))]
+         [else
+          ;; (define NAME VAL): walk val, target is a binding.
+          (walk-refs (caddr expr) refs shadowed)]))]
+    [(eq? (car expr) 'set!)
+     (when (and (symbol? (cadr expr))
+                (not (member (cadr expr) shadowed)))
+       (hash-set! refs (cadr expr) #t))
+     (when (= (length expr) 3)
+       (walk-refs (caddr expr) refs shadowed))]
+    [else
+     (for-each (lambda (e) (walk-refs e refs shadowed)) expr)]))
+
+;; ---------------------------------------------------------------------------
+;; Rewrite
+
+;; Top-level pass that drops dead defines. For each (define NAME VAL)
+;; whose NAME is in dead-set:
+;;   - if VAL is pure: remove the entire form;
+;;   - otherwise: replace the form with VAL alone so the side effects
+;;     still run at program startup.
+;; Non-define forms pass through unchanged.
+(define (rewrite-dropping exprs dead-set)
+  (apply append
+    (map (lambda (e)
+           (let ([n (define-name e)])
+             (cond
+               [(and n (hash-ref dead-set n #f))
+                (let ([val (define-value e)])
+                  (cond
+                    [(or (not val) (pure? val)) '()]
+                    [else (list val)]))]
+               [else (list e)])))
+         exprs)))

--- a/languages/scheme-racket/main.rkt
+++ b/languages/scheme-racket/main.rkt
@@ -32,6 +32,7 @@
 ;; Uses CL-style pre-allocation: expression 0 is pre-allocated as entry point
 ;; source-file: optional path for resolving include directives
 (define (compile-string source-code [source-file #f])
+  (opt-stats-reset!)
   (let* ([exprs (read-all-exprs source-code source-file)]
          ;; Expand macros first (handles define-syntax)
          ;; Filter out *FILTERED* sentinel values (from define-syntax)
@@ -80,6 +81,10 @@
 
     ) ; close parameterize
 
+    ;; Optimisation stats summary, after all rules have fired.
+    (when (opt-stats?)
+      (opt-stats-print))
+
     ;; Return the bytecode - no reversal, no form reference fixing!
     bc))
 
@@ -110,6 +115,8 @@
    [("--debug") "Debug mode" (debug-mode #t)]
    [("--opt-level") level "Optimization level (0-2, default 1)" (optimization-level (string->number level))]
    [("--no-optimize") "Disable all optimizations" (enable-optimizations #f)]
+   [("--opt-stats") "Print per-bucket optimization fire counts to stderr" (opt-stats? #t)]
+   [("--trace-opts") "Trace each optimization rewrite to stderr" (opt-trace? #t)]
    #:args (source-file)
    (compile-file source-file)))
 

--- a/languages/scheme-racket/main.rkt
+++ b/languages/scheme-racket/main.rkt
@@ -7,6 +7,7 @@
          "expander.rkt"  ; Macro expansion
          "rewriter.rkt"
          "optimizer.rkt"  ; Optimizations
+         "dead-define.rkt"    ; Strip unreferenced top-level defines
          "errors.rkt"     ; Error handling
          "compiler.rkt"
          "bytecode.rkt")
@@ -42,11 +43,13 @@
          [finalized (map finalize-guard rewritten)]
          ;; Optimize expressions (constant folding, etc.)
          [optimized (map optimize-expr finalized)]
+         ;; Strip top-level defines whose names are never referenced.
+         [pruned (eliminate-dead-defines optimized)]
          ;; Collect top-level user (define name ...) names that also
          ;; happen to be VM primitives. encode-symbol will route call
          ;; sites of these names to the user binding rather than the
          ;; primitive ID.
-         [shadowed (collect-shadowed-primitives optimized)]
+         [shadowed (collect-shadowed-primitives pruned)]
          ;; Create main bytecode with pre-allocated expression 0
          [bc (make-bytecode)]
          ;; Pre-allocate expression 0 as empty placeholder (will be replaced)
@@ -58,7 +61,7 @@
     (parameterize ([current-shadowed-primitives shadowed])
     (let* ([accumulated-bytes
             (apply append
-              (for/list ([expr optimized])
+              (for/list ([expr pruned])
                 (let ([enc (compile-expr expr bc)])  ; Compile into bc, not temp-bc!
                   (expr-encoding-data enc))))])
 
@@ -68,7 +71,7 @@
 
       ;; DEBUG
       (when (debug-mode)
-        (printf "DEBUG: Compiled ~a top-level expressions\n" (length optimized))
+        (printf "DEBUG: Compiled ~a top-level expressions\n" (length pruned))
         (printf "DEBUG: Accumulated ~a bytes total\n" (length accumulated-bytes))
         (printf "DEBUG: bc has ~a expressions\n" (bytecode-expression-count bc))
         (for ([i (in-naturals)]

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -36,36 +36,72 @@
 ;; Basic Optimizations (Level 1)
 ;; ============================================================================
 
+;; Post-order rewrite: optimize children first, then apply local rules at
+;; this node and iterate until they stop firing. Bottom-up is required so
+;; that a fold in a sub-expression feeds the outer rule:
+;;   (+ (- 3 1) 4)
+;;     children -> (+ 2 4)
+;;     local rule -> 6
+;; Top-down would never fold the outer (+) because (- 3 1) is still a pair
+;; when the outer rule is tested. Local fixpoint also handles cases where
+;; one rule's output enables another, e.g. (not (= 1 1)) -> (not #t) -> #t.
 (define (optimize-basic expr)
+  (cond
+    ;; Atoms have nothing to fold.
+    [(not (pair? expr)) expr]
+
+    ;; Quote: R5RS forbids evaluating the datum, so we must not recurse
+    ;; into it (and no rule rewrites a quote form).
+    [(eq? (car expr) 'quote) expr]
+
+    ;; lambda: the formal-parameter spec is metadata and may be a
+    ;; dotted-pair list or bare symbol for variadic lambdas. Optimize the
+    ;; body, leave the formals untouched.
+    [(and (eq? (car expr) 'lambda) (>= (length expr) 3))
+     `(lambda ,(cadr expr) ,@(map optimize-basic (cddr expr)))]
+
+    ;; (define (name . formals) body...): same treatment as lambda.
+    ;; (define name value) falls through to the general case.
+    [(and (eq? (car expr) 'define) (pair? (cadr expr)))
+     `(define ,(cadr expr) ,@(map optimize-basic (cddr expr)))]
+
+    ;; General compound form: post-order recurse, then run local rules
+    ;; to fixpoint at this node.
+    [else
+     (apply-basic-rules-fixpoint
+      (cons (optimize-basic (car expr))
+            (map optimize-basic (cdr expr))))]))
+
+;; Apply local rules until they stop firing at this node. eq? is the
+;; right termination check: rules that fire either build a fresh value
+;; (e.g. (+ 1 2) -> 3) or return a sub-element (e.g. (+ e 0) -> e), and
+;; in both cases the result is not eq? to the input pair. When no rule
+;; matches, apply-basic-rules returns the input unchanged and eq?
+;; succeeds.
+(define (apply-basic-rules-fixpoint expr)
+  (let ([next (apply-basic-rules expr)])
+    (if (eq? next expr)
+        expr
+        (apply-basic-rules-fixpoint next))))
+
+;; Local rules. Each operates on the current node only and assumes
+;; children are already optimized -- so identity rules can return the
+;; surviving sub-expression directly without re-running optimize-basic.
+(define (apply-basic-rules expr)
   (match expr
     ;; Constant folding for arithmetic
-    [`(+ ,n1 ,n2) #:when (and (number? n1) (number? n2))
-     (+ n1 n2)]
-
-    [`(- ,n1 ,n2) #:when (and (number? n1) (number? n2))
-     (- n1 n2)]
-
-    [`(* ,n1 ,n2) #:when (and (number? n1) (number? n2))
-     (* n1 n2)]
-
+    [`(+ ,n1 ,n2) #:when (and (number? n1) (number? n2)) (+ n1 n2)]
+    [`(- ,n1 ,n2) #:when (and (number? n1) (number? n2)) (- n1 n2)]
+    [`(* ,n1 ,n2) #:when (and (number? n1) (number? n2)) (* n1 n2)]
     [`(/ ,n1 ,n2) #:when (and (number? n1) (number? n2) (not (zero? n2)))
      (/ n1 n2)]
 
     ;; Constant folding for comparisons
-    [`(= ,n1 ,n2) #:when (and (number? n1) (number? n2))
-     (= n1 n2)]
-
-    [`(< ,n1 ,n2) #:when (and (number? n1) (number? n2))
-     (< n1 n2)]
-
-    [`(> ,n1 ,n2) #:when (and (number? n1) (number? n2))
-     (> n1 n2)]
-
-    [`(<= ,n1 ,n2) #:when (and (number? n1) (number? n2))
-     (<= n1 n2)]
-
-    [`(>= ,n1 ,n2) #:when (and (number? n1) (number? n2))
-     (>= n1 n2)]
+    [`(= ,n1 ,n2) #:when (and (number? n1) (number? n2)) (= n1 n2)]
+    [`(< ,n1 ,n2) #:when (and (number? n1) (number? n2)) (< n1 n2)]
+    [`(> ,n1 ,n2) #:when (and (number? n1) (number? n2)) (> n1 n2)]
+    [`(<= ,n1 ,n2) #:when (and (number? n1) (number? n2)) (<= n1 n2)]
+    [`(>= ,n1 ,n2) #:when (and (number? n1) (number? n2)) (>= n1 n2)]
 
     ;; Constant folding for boolean operations
     [`(not #t) #f]
@@ -73,48 +109,23 @@
     [`(not ,b) #:when (boolean? b) (not b)]
 
     ;; Identity optimizations
-    [`(+ ,expr 0) (optimize-basic expr)]
-    [`(+ 0 ,expr) (optimize-basic expr)]
-    [`(- ,expr 0) (optimize-basic expr)]
-    [`(* ,expr 1) (optimize-basic expr)]
-    [`(* 1 ,expr) (optimize-basic expr)]
-    [`(* ,expr 0) 0]
-    [`(* 0 ,expr) 0]
+    [`(+ ,e 0) e]
+    [`(+ 0 ,e) e]
+    [`(- ,e 0) e]
+    [`(* ,e 1) e]
+    [`(* 1 ,e) e]
+    [`(* ,e 0) 0]
+    [`(* 0 ,e) 0]
 
     ;; If optimizations
-    [`(if #t ,conseq ,_) (optimize-basic conseq)]
-    [`(if #f ,_ ,alt) (optimize-basic alt)]
+    [`(if #t ,conseq ,_) conseq]
+    [`(if #f ,_ ,alt) alt]
 
     ;; Begin optimizations
-    [`(begin) #f]  ; Empty begin
-    [`(begin ,expr) (optimize-basic expr)]  ; Single expression
+    [`(begin) #f]
+    [`(begin ,e) e]
 
-    ;; Quote: DO NOT optimize quoted expressions!
-    ;; R5RS: quote suppresses ALL evaluation, so we must not perform
-    ;; constant folding or any other optimizations on quoted data.
-    [`(quote ,datum) expr]  ; Return as-is, don't recurse into datum
-
-    ;; lambda: the formal-parameter spec is metadata, not code, and may
-    ;; be a dotted-pair list or bare symbol for variadic lambdas. Walk
-    ;; the body, leave the formals untouched.
-    [(? (lambda (e)
-          (and (pair? e) (eq? (car e) 'lambda) (>= (length e) 3))) expr)
-     `(lambda ,(cadr expr)
-        ,@(map optimize-basic (cddr expr)))]
-
-    ;; (define (name . rest-or-formals) body...): function-shorthand
-    ;; define carries the formal-parameter spec in (cadr expr), which
-    ;; like lambda's may be improper. Skip it and walk the body only.
-    [(? (lambda (e)
-          (and (pair? e) (eq? (car e) 'define) (pair? (cadr e)))) expr)
-     `(define ,(cadr expr)
-        ,@(map optimize-basic (cddr expr)))]
-
-    ;; Recursively optimize sub-expressions
-    [(cons head tail)
-     (cons (optimize-basic head) (map optimize-basic tail))]
-
-    ;; Atoms and other expressions
+    ;; No rule matched.
     [else expr]))
 
 ;; ============================================================================

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -72,14 +72,17 @@
       (cons (optimize-basic (car expr))
             (map optimize-basic (cdr expr))))]))
 
-;; Apply local rules until they stop firing at this node. eq? is the
-;; right termination check: rules that fire either build a fresh value
-;; (e.g. (+ 1 2) -> 3) or return a sub-element (e.g. (+ e 0) -> e), and
-;; in both cases the result is not eq? to the input pair. When no rule
-;; matches, apply-basic-rules returns the input unchanged and eq?
-;; succeeds.
+;; Apply local rules until they stop firing at this node. Beta-reduction
+;; is tried first; if it doesn't fire, the constant-folding match rules
+;; run. eq? is the right termination check: rules that fire either build
+;; a fresh value (e.g. (+ 1 2) -> 3) or return a sub-element (e.g.
+;; (+ e 0) -> e), and in both cases the result is not eq? to the input.
+;; When neither pass changes the expression, eq? succeeds.
 (define (apply-basic-rules-fixpoint expr)
-  (let ([next (apply-basic-rules expr)])
+  (let* ([beta (try-beta-reduce expr)]
+         [next (if (eq? beta expr)
+                   (apply-basic-rules expr)
+                   beta)])
     (if (eq? next expr)
         expr
         (apply-basic-rules-fixpoint next))))
@@ -127,6 +130,164 @@
 
     ;; No rule matched.
     [else expr]))
+
+;; ============================================================================
+;; Beta-reduction of let bindings
+;; ============================================================================
+
+;; The let rewriter turns (let ((x v)) body) into ((lambda (x) body) v),
+;; which allocates a bind_function frame at runtime. When v is a literal
+;; with no allocation cost, we can drop that binding entirely by inlining
+;; v at every reference of x. The lambda disappears once all its
+;; parameters are inlined, eliminating the frame allocation.
+;;
+;; Conservative literal predicate: a value is safe to duplicate at
+;; arbitrary use sites if it is self-evaluating and has no eq? identity.
+;; Numbers, booleans, characters, and atomic quoted data qualify.
+;; Strings and quoted lists/vectors are excluded -- strings have eq?
+;; identity, and quoted lists currently allocate fresh storage at each
+;; evaluation (item #3 will fix the latter; until then, duplicating a
+;; quoted list use can be a runtime regression).
+(define (beta-literal? v)
+  (or (number? v)
+      (boolean? v)
+      (char? v)
+      (and (pair? v)
+           (eq? (car v) 'quote)
+           (= (length v) 2)
+           (let ([d (cadr v)])
+             (or (symbol? d) (null? d)
+                 (number? d) (boolean? d) (char? d))))))
+
+;; Try to beta-reduce ((lambda (params...) body...) args...). Inlines
+;; each parameter whose value is a literal (see beta-literal?) and
+;; whose binding is never the target of a set!. Returns the input expr
+;; unchanged if no parameters could be inlined, otherwise returns the
+;; inlined body run through optimize-basic so newly-exposed folds fire.
+;; Variadic lambdas (dotted or bare-symbol formals) are skipped.
+(define (try-beta-reduce expr)
+  (cond
+    [(and (pair? expr)
+          (pair? (car expr))
+          (eq? (caar expr) 'lambda)
+          (>= (length (car expr)) 3)
+          (proper-list-of-symbols? (cadar expr))
+          (= (length (cadar expr)) (length (cdr expr))))
+     (let* ([params (cadar expr)]
+            [body-list (cddar expr)]
+            [body (if (= (length body-list) 1)
+                      (car body-list)
+                      `(begin ,@body-list))]
+            [args (cdr expr)]
+            [reduced (beta-fold params args body expr)])
+       (if (eq? reduced expr)
+           expr
+           ;; Re-walk so substituted literals can feed folding rules in
+           ;; the surrounding positions.
+           (optimize-basic reduced)))]
+    [else expr]))
+
+;; Walk (param, arg) pairs in order, inlining each pair where arg is a
+;; beta-literal and param has no set! in body. Returns:
+;;   - `original` (the input expr) if nothing changed,
+;;   - the substituted body if all parameters were inlined,
+;;   - a smaller (lambda+args) for the partial-inline case.
+(define (beta-fold params args body original)
+  (let loop ([params params] [args args]
+             [keep-params '()] [keep-args '()]
+             [body body] [changed? #f])
+    (cond
+      [(null? params)
+       (cond
+         [(not changed?) original]
+         [(null? keep-params) body]
+         [else `((lambda ,(reverse keep-params) ,body)
+                 ,@(reverse keep-args))])]
+      [else
+       (let ([p (car params)] [a (car args)])
+         (if (and (beta-literal? a)
+                  (= (count-set!s body p) 0))
+             (loop (cdr params) (cdr args)
+                   keep-params keep-args
+                   (substitute body p a) #t)
+             (loop (cdr params) (cdr args)
+                   (cons p keep-params) (cons a keep-args)
+                   body changed?)))])))
+
+(define (proper-list-of-symbols? xs)
+  (cond
+    [(null? xs) #t]
+    [(pair? xs) (and (symbol? (car xs))
+                     (proper-list-of-symbols? (cdr xs)))]
+    [else #f]))
+
+;; Flatten a formal-parameter spec (proper, dotted, or bare-symbol) into
+;; a plain list for shadow checks. Mirrors compiler.rkt's helper.
+(define (formals->flat-list formals)
+  (cond
+    [(null? formals) '()]
+    [(symbol? formals) (list formals)]
+    [(pair? formals) (cons (car formals) (formals->flat-list (cdr formals)))]
+    [else '()]))
+
+;; Substitute free occurrences of `name` with `value` in `expr`,
+;; respecting binder forms (lambda formals, define-shorthand formals,
+;; (define name ...) targets) and quote opacity. set! targets are
+;; binding positions, not references, so they are not substituted; the
+;; assignment value is.
+(define (substitute expr name value)
+  (cond
+    [(eq? expr name) value]
+    [(symbol? expr) expr]
+    [(not (pair? expr)) expr]
+    [(eq? (car expr) 'quote) expr]
+    [(and (eq? (car expr) 'lambda) (>= (length expr) 3))
+     (if (member name (formals->flat-list (cadr expr)))
+         expr
+         `(lambda ,(cadr expr)
+            ,@(map (lambda (e) (substitute e name value)) (cddr expr))))]
+    [(and (eq? (car expr) 'define) (>= (length expr) 3))
+     (let ([target (cadr expr)])
+       (cond
+         [(eq? target name) expr]
+         [(and (pair? target)
+               (or (eq? (car target) name)
+                   (member name (formals->flat-list (cdr target)))))
+          expr]
+         [else
+          `(define ,target
+             ,@(map (lambda (e) (substitute e name value)) (cddr expr)))]))]
+    [(eq? (car expr) 'set!)
+     `(set! ,(cadr expr) ,(substitute (caddr expr) name value))]
+    [else
+     (cons (substitute (car expr) name value)
+           (map (lambda (e) (substitute e name value)) (cdr expr)))]))
+
+;; Count set! statements targeting `name` in `expr`, respecting the
+;; same scope rules as substitute.
+(define (count-set!s expr name)
+  (cond
+    [(symbol? expr) 0]
+    [(not (pair? expr)) 0]
+    [(eq? (car expr) 'quote) 0]
+    [(and (eq? (car expr) 'lambda) (>= (length expr) 3))
+     (if (member name (formals->flat-list (cadr expr)))
+         0
+         (apply + (map (lambda (e) (count-set!s e name)) (cddr expr))))]
+    [(and (eq? (car expr) 'define) (>= (length expr) 3))
+     (let ([target (cadr expr)])
+       (cond
+         [(eq? target name) 0]
+         [(and (pair? target)
+               (or (eq? (car target) name)
+                   (member name (formals->flat-list (cdr target)))))
+          0]
+         [else (apply + (map (lambda (e) (count-set!s e name)) (cddr expr)))]))]
+    [(eq? (car expr) 'set!)
+     (+ (if (eq? (cadr expr) name) 1 0)
+        (count-set!s (caddr expr) name))]
+    [else
+     (apply + (map (lambda (e) (count-set!s e name)) expr))]))
 
 ;; ============================================================================
 ;; Aggressive Optimizations (Level 2)

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -92,19 +92,27 @@
 ;; surviving sub-expression directly without re-running optimize-basic.
 (define (apply-basic-rules expr)
   (match expr
-    ;; Constant folding for arithmetic
-    [`(+ ,n1 ,n2) #:when (and (number? n1) (number? n2)) (+ n1 n2)]
-    [`(- ,n1 ,n2) #:when (and (number? n1) (number? n2)) (- n1 n2)]
-    [`(* ,n1 ,n2) #:when (and (number? n1) (number? n2)) (* n1 n2)]
-    [`(/ ,n1 ,n2) #:when (and (number? n1) (number? n2) (not (zero? n2)))
-     (/ n1 n2)]
+    ;; Variadic constant folding for arithmetic. Matches any arity
+    ;; where every argument is a literal number. Subsumes the prior
+    ;; binary-only rules.
+    [(list '+ (? number? ns) ...) (apply + ns)]
+    [(list '* (? number? ns) ...) (apply * ns)]
+    [(list '- (? number? ns) ...)
+     #:when (not (null? ns))
+     (apply - ns)]
+    [(list '/ (? number? ns) ...)
+     #:when (and (>= (length ns) 2) (not (member 0 (cdr ns))))
+     (apply / ns)]
 
-    ;; Constant folding for comparisons
-    [`(= ,n1 ,n2) #:when (and (number? n1) (number? n2)) (= n1 n2)]
-    [`(< ,n1 ,n2) #:when (and (number? n1) (number? n2)) (< n1 n2)]
-    [`(> ,n1 ,n2) #:when (and (number? n1) (number? n2)) (> n1 n2)]
-    [`(<= ,n1 ,n2) #:when (and (number? n1) (number? n2)) (<= n1 n2)]
-    [`(>= ,n1 ,n2) #:when (and (number? n1) (number? n2)) (>= n1 n2)]
+    ;; Variadic constant folding for comparisons. R5RS requires at
+    ;; least one argument; we fold the typical case of two or more
+    ;; (single-arg comparisons are vacuously true and aren't worth
+    ;; a rule).
+    [(list '= (? number? ns) ...)  #:when (>= (length ns) 2) (apply = ns)]
+    [(list '< (? number? ns) ...)  #:when (>= (length ns) 2) (apply < ns)]
+    [(list '> (? number? ns) ...)  #:when (>= (length ns) 2) (apply > ns)]
+    [(list '<= (? number? ns) ...) #:when (>= (length ns) 2) (apply <= ns)]
+    [(list '>= (? number? ns) ...) #:when (>= (length ns) 2) (apply >= ns)]
 
     ;; Constant folding for boolean operations. The general (not LIT)
     ;; rule below subsumes the (not #t) / (not #f) cases.
@@ -127,6 +135,17 @@
     ;; Begin optimizations
     [`(begin) #f]
     [`(begin ,e) e]
+    ;; Drop pure non-final expressions: their values are discarded
+    ;; and they can't be observed. The final expression's value is
+    ;; the begin's value and must be kept even when pure.
+    [(list 'begin es ...)
+     #:when (and (>= (length es) 2)
+                 (ormap pure? (drop-right es 1)))
+     (let ([kept (drop-pure-non-final es)])
+       (cond
+         [(null? kept) #f]
+         [(= (length kept) 1) (car kept)]
+         [else (cons 'begin kept)]))]
 
     ;; ---- Pure-builtin folding ----
     ;; All of these have well-defined value semantics that depend only
@@ -432,29 +451,74 @@
       [else basic])))
 
 ;; ============================================================================
-;; Dead Code Elimination
+;; Effect Analysis (used by the begin dead-code rule)
 ;; ============================================================================
 
-(define (has-side-effects? expr)
-  "Check if expression has side effects (must be evaluated)"
-  (match expr
-    ;; Forms with side effects
-    [`(define . ,_) #t]
-    [`(set! . ,_) #t]
-    [`(print . ,_) #t]
-    [`(display . ,_) #t]
-    [`(write . ,_) #t]
-    [`(write-char . ,_) #t]
+;; VM primitives whose execution is observable only through their
+;; return value. They never modify state, never perform I/O, and
+;; never spawn threads. Allocation (cons, list, vector) is treated
+;; as pure -- R5RS programs cannot observe GC, and dropping a pure
+;; allocation just saves work. Some of these can raise errors
+;; (e.g. car on '()); we accept that risk on the same footing as
+;; Racket's own dead-code elimination.
+(define pure-primitive-table
+  (let ([h (make-hash)])
+    (for ([sym (in-list
+                '(+ - * / gcd lcm modulo quotient remainder
+                  numerator denominator
+                  = /= < <= > >= zero?
+                  eq? eqv? equal? not
+                  car cdr cons list pair? null? list? length
+                  reverse append memq memv member assq assv assoc
+                  list-ref list-tail
+                  vector vector? vector-length vector-ref
+                  vector->list list->vector make-vector
+                  string? string-length string-ref substring
+                  string-append string-copy string-compare
+                  string->list list->string make-string
+                  string->symbol symbol->string
+                  string->number number->string
+                  char? char-compare char-class
+                  char->integer integer->char
+                  char-upcase char-downcase
+                  number? integer? rational? real? complex?
+                  exact? inexact? procedure? symbol? boolean? port?
+                  abs max min
+                  floor ceiling round truncate
+                  exp log sin cos tan asin acos atan
+                  sqrt expt exact->inexact inexact->exact
+                  bit-and bit-or bit-invert bit-not bit-xor bit-shift
+                  box box-ref))])
+      (hash-set! h sym #t))
+    h))
 
-    ;; Function calls might have side effects (conservative)
-    [(cons _ _) #t]
+(define (pure-primitive? sym)
+  (hash-ref pure-primitive-table sym #f))
 
-    ;; Pure values
-    [_ #f]))
+;; True iff `expr` can be evaluated without observable side effects:
+;; no I/O, no mutation, no thread interaction, no application of
+;; potentially-impure user procedures. Lambda forms are pure (they
+;; don't evaluate the body). Variable references and atoms are pure.
+;; Pure-primitive calls are pure iff all argument expressions are pure.
+(define (pure? expr)
+  (cond
+    [(not (pair? expr)) #t]
+    [(eq? (car expr) 'quote) #t]
+    [(and (eq? (car expr) 'lambda) (>= (length expr) 3)) #t]
+    [(eq? (car expr) 'if) (andmap pure? (cdr expr))]
+    [(eq? (car expr) 'and) (andmap pure? (cdr expr))]
+    [(eq? (car expr) 'or) (andmap pure? (cdr expr))]
+    [(eq? (car expr) 'begin) (andmap pure? (cdr expr))]
+    [(and (symbol? (car expr)) (pure-primitive? (car expr)))
+     (andmap pure? (cdr expr))]
+    [else #f]))
 
-(define (eliminate-dead-code exprs)
-  "Remove expressions without side effects from a sequence"
-  (filter has-side-effects? exprs))
+;; Used by the (begin) optimization rule below. Filters out pure
+;; expressions in non-final position; the final expression's value
+;; is the begin's value and must be kept regardless of purity.
+(define (drop-pure-non-final exprs)
+  (let-values ([(non-final final) (split-at-right exprs 1)])
+    (append (filter (lambda (e) (not (pure? e))) non-final) final)))
 
 ;; ============================================================================
 ;; Optimization Statistics

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -11,7 +11,14 @@
 (provide optimize-expr
          enable-optimizations
          optimization-level
-         pure?)
+         pure?
+         ;; tracing/stats infrastructure shared with the rewriter and
+         ;; dead-define passes
+         opt-trace?
+         opt-stats?
+         opt-stats-reset!
+         opt-stats-print
+         opt-note-fire!)
 
 ;; Optimization parameters
 (define enable-optimizations (make-parameter #t))
@@ -81,9 +88,11 @@
 ;; When neither pass changes the expression, eq? succeeds.
 (define (apply-basic-rules-fixpoint expr)
   (let* ([beta (try-beta-reduce expr)]
-         [next (if (eq? beta expr)
-                   (apply-basic-rules expr)
-                   beta)])
+         [from-beta? (not (eq? beta expr))]
+         [next (if from-beta? beta (apply-basic-rules expr))]
+         [from-basic? (and (not from-beta?) (not (eq? next expr)))])
+    (when from-beta? (opt-note-fire! 'beta-reduce expr next))
+    (when from-basic? (opt-note-fire! (opt-bucket-for expr) expr next))
     (if (eq? next expr)
         expr
         (apply-basic-rules-fixpoint next))))
@@ -652,19 +661,71 @@
     (append (filter (lambda (e) (not (pure? e))) non-final) final)))
 
 ;; ============================================================================
-;; Optimization Statistics
+;; Optimization tracing and stats
 ;; ============================================================================
 
-(define optimization-stats (make-hash))
+;; --trace-opts prints every rewrite to stderr as it happens.
+;; --opt-stats prints a per-bucket fire-count summary at compile end.
+;; Both are driven by parameters so the surrounding pipeline can flip
+;; them on/off without re-threading arguments.
+(define opt-trace? (make-parameter #f))
+(define opt-stats? (make-parameter #f))
 
-(define (record-optimization type)
-  (hash-update! optimization-stats type add1 0))
+(define opt-stats-table (make-hash))
 
-(define (get-optimization-stats)
-  (hash-copy optimization-stats))
+(define (opt-stats-reset!)
+  (hash-clear! opt-stats-table))
 
-(define (reset-optimization-stats!)
-  (set! optimization-stats (make-hash)))
+(define (opt-note-fire! bucket before after)
+  (when (opt-stats?)
+    (hash-update! opt-stats-table bucket add1 0))
+  (when (opt-trace?)
+    (eprintf "~a: ~v -> ~v~n" bucket before after)))
+
+;; Bucket name for an optimizer-rule fire, derived from the input
+;; expression's head. Coarse but useful: all (+ ...) folds share one
+;; bucket; identity-op rules go to the same bucket as the arithmetic
+;; folds for their operator, which matches what someone debugging the
+;; optimizer typically wants to see.
+(define (opt-bucket-for expr)
+  (cond
+    [(not (pair? expr)) 'unknown]
+    [(eq? (car expr) '+) 'fold-+]
+    [(eq? (car expr) '-) 'fold--]
+    [(eq? (car expr) '*) 'fold-*]
+    [(eq? (car expr) '/) 'fold-/]
+    [(eq? (car expr) '=) 'fold-=]
+    [(memq (car expr) '(< <= > >=)) 'fold-cmp]
+    [(eq? (car expr) 'not) 'fold-not]
+    [(eq? (car expr) 'if) 'fold-if]
+    [(eq? (car expr) 'begin) 'fold-begin]
+    [(eq? (car expr) 'and) 'fold-and]
+    [(eq? (car expr) 'or) 'fold-or]
+    [(eq? (car expr) 'apply) 'fold-apply]
+    [(memq (car expr) '(length string-length string-append
+                        char->integer integer->char string->symbol
+                        eq? eqv? equal?))
+     'fold-pure-builtin]
+    [else (car expr)]))
+
+(define (opt-stats-print [port (current-error-port)])
+  (define entries
+    (sort (hash-map opt-stats-table cons)
+          (lambda (a b) (> (cdr a) (cdr b)))))
+  (cond
+    [(null? entries)
+     (fprintf port "optimizations fired: none~n")]
+    [else
+     (fprintf port "optimizations fired:~n")
+     (define namewidth
+       (apply max (map (lambda (e) (string-length (symbol->string (car e))))
+                       entries)))
+     (for ([entry (in-list entries)])
+       (fprintf port "  ~a~a  ~a~n"
+                (car entry)
+                (make-string (- namewidth (string-length (symbol->string (car entry))))
+                             #\space)
+                (cdr entry)))]))
 
 ;; ============================================================================
 ;; Utilities

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -106,10 +106,10 @@
     [`(<= ,n1 ,n2) #:when (and (number? n1) (number? n2)) (<= n1 n2)]
     [`(>= ,n1 ,n2) #:when (and (number? n1) (number? n2)) (>= n1 n2)]
 
-    ;; Constant folding for boolean operations
-    [`(not #t) #f]
-    [`(not #f) #t]
-    [`(not ,b) #:when (boolean? b) (not b)]
+    ;; Constant folding for boolean operations. The general (not LIT)
+    ;; rule below subsumes the (not #t) / (not #f) cases.
+    [`(not ,v) #:when (literal-truthy-known? v) (not v)]
+    [`(not (quote ,d)) (not d)]
 
     ;; Identity optimizations
     [`(+ ,e 0) e]
@@ -128,8 +128,102 @@
     [`(begin) #f]
     [`(begin ,e) e]
 
+    ;; ---- Pure-builtin folding ----
+    ;; All of these have well-defined value semantics that depend only
+    ;; on their (literal) arguments; running them at compile time is
+    ;; observationally equivalent to running them at runtime.
+
+    ;; (length '(...)) -> integer (only for proper-list datums; the
+    ;; compile-quote path handles those)
+    [`(length (quote ,d)) #:when (list? d) (length d)]
+
+    ;; (string-length "...") -> integer
+    [`(string-length ,s) #:when (string? s) (string-length s)]
+
+    ;; (string-append "a" "b" ...) -> concatenated string. Variadic;
+    ;; (string-append) folds to "".
+    [(list 'string-append (? string? ss) ...) (apply string-append ss)]
+
+    ;; (char->integer #\X) -> codepoint
+    [`(char->integer ,c) #:when (char? c) (char->integer c)]
+
+    ;; (integer->char N) -> #\X. The VM stores characters as uint8_t,
+    ;; so refuse to fold codepoints outside [0, 255] -- the runtime
+    ;; would reject them and we don't want to bake a value the
+    ;; encoder can't emit.
+    [`(integer->char ,n)
+     #:when (and (exact-integer? n) (>= n 0) (<= n 255))
+     (integer->char n)]
+
+    ;; (string->symbol "name") -> 'name
+    [`(string->symbol ,s) #:when (string? s)
+     (list 'quote (string->symbol s))]
+
+    ;; eq? on literals with deterministic identity. There are two
+    ;; channels: (quote DATUM) where DATUM is an interned-atomic, and
+    ;; bare self-evaluating literals. A bare SYMBOL in source is a
+    ;; variable reference, never a literal -- so symbols are foldable
+    ;; only under quote, not as bare arguments.
+    [`(eq? (quote ,a) (quote ,b))
+     #:when (and (eq-foldable-quoted? a) (eq-foldable-quoted? b))
+     (eq? a b)]
+    [`(eq? ,a ,b)
+     #:when (and (eq-foldable-unquoted? a) (eq-foldable-unquoted? b))
+     (eq? a b)]
+
+    ;; eqv? extends eq? with numbers (well-defined across exact/inexact).
+    [`(eqv? (quote ,a) (quote ,b))
+     #:when (and (eqv-foldable-quoted? a) (eqv-foldable-quoted? b))
+     (eqv? a b)]
+    [`(eqv? ,a ,b)
+     #:when (and (eqv-foldable-unquoted? a) (eqv-foldable-unquoted? b))
+     (eqv? a b)]
+
+    ;; equal? is structural and safe to fold on any pair of literal
+    ;; data, including nested quoted lists/vectors.
+    [`(equal? (quote ,a) (quote ,b)) (equal? a b)]
+    [`(equal? ,a ,b)
+     #:when (and (self-evaluating-literal? a)
+                 (self-evaluating-literal? b))
+     (equal? a b)]
+
     ;; No rule matched.
     [else expr]))
+
+;; ============================================================================
+;; Predicates supporting pure-builtin folding
+;; ============================================================================
+
+;; The (not LIT) rule above fires when we can statically determine
+;; the literal's truthiness. Every value here has a known boolean
+;; coercion: #f is false, everything else is true (R5RS 6.3.1).
+(define (literal-truthy-known? v)
+  (or (number? v) (boolean? v) (char? v) (string? v)))
+
+;; Inside (quote DATUM), DATUM is a literal regardless of its shape;
+;; eq? has deterministic identity on symbols (interned), booleans
+;; (unique values), characters, and the empty list.
+(define (eq-foldable-quoted? x)
+  (or (symbol? x) (boolean? x) (char? x) (null? x)))
+
+;; eqv? extends eq? to numbers (well-defined across exact/inexact).
+(define (eqv-foldable-quoted? x)
+  (or (eq-foldable-quoted? x) (number? x)))
+
+;; When the argument is NOT wrapped in quote, only self-evaluating
+;; literals count -- symbols, () and similar reach this position only
+;; as variable references. Folding (eq? sym1 sym2) would treat the
+;; variable names as values.
+(define (eq-foldable-unquoted? x)
+  (or (boolean? x) (char? x)))
+
+(define (eqv-foldable-unquoted? x)
+  (or (eq-foldable-unquoted? x) (number? x)))
+
+;; A self-evaluating literal in source -- includes strings, which are
+;; not interned-identity-comparable, so they're only safe for equal?.
+(define (self-evaluating-literal? x)
+  (or (number? x) (boolean? x) (char? x) (string? x)))
 
 ;; ============================================================================
 ;; Beta-reduction of let bindings

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -119,6 +119,30 @@
     ;; rule below subsumes the (not #t) / (not #f) cases.
     [`(not ,v) #:when (literal-truthy-known? v) (not v)]
     [`(not (quote ,d)) (not d)]
+
+    ;; and/or short-circuit folding. R5RS: (and) = #t, (or) = #f;
+    ;; both forms short-circuit on the first determining argument.
+    ;; Eliminating the unreachable tail trims free-variable
+    ;; references that would otherwise widen closure capture sets
+    ;; (item #17 framing).
+    [(list 'and) #t]
+    [(list 'or) #f]
+    [`(and ,e) e]
+    [`(or ,e) e]
+    ;; (and X1 ... #f ...): #f stops evaluation; any preceding pure
+    ;; sub-expressions are dropped, impure ones survive in a begin.
+    [(list 'and es ...)
+     #:when (and (not (null? es)) (memq #f es))
+     (let* ([prefix (takef es (lambda (e) (not (eq? e #f))))]
+            [impure (filter (lambda (e) (not (pure? e))) prefix)])
+       (cond
+         [(null? impure) #f]
+         [else `(begin ,@impure #f)]))]
+    ;; (or LIT-TRUTHY ...): the first arg short-circuits, drop the
+    ;; rest. Truthy here means any non-#f literal.
+    [(list 'or first rest ...)
+     #:when (and (not (null? rest)) (literal-truthy? first))
+     first]
     ;; (not (not x)) -> x, but only when x is provably boolean. For a
     ;; non-boolean x the original form coerces to a boolean while x
     ;; itself doesn't: (not (not 5)) is #t, 5 is 5. We don't have a
@@ -287,6 +311,19 @@
 ;; coercion: #f is false, everything else is true (R5RS 6.3.1).
 (define (literal-truthy-known? v)
   (or (number? v) (boolean? v) (char? v) (string? v)))
+
+;; True iff v is a literal whose runtime value is truthy. R5RS 6.3.1:
+;; only #f is false; everything else (including 0, '(), "", #\null)
+;; is true. A (quote ...) form counts because quote's value is a
+;; literal datum.
+(define (literal-truthy? v)
+  (cond
+    [(boolean? v) v]
+    [(number? v) #t]
+    [(char? v) #t]
+    [(string? v) #t]
+    [(and (pair? v) (eq? (car v) 'quote)) #t]
+    [else #f]))
 
 ;; Inside (quote DATUM), DATUM is a literal regardless of its shape;
 ;; eq? has deterministic identity on symbols (interned), booleans

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -303,9 +303,18 @@
       [`(* (* ,a ,b) ,c) #:when (and (number? b) (number? c))
        (optimize-aggressive `(* ,a ,(* b c)))]
 
-      ;; Strength reduction
-      [`(* ,expr 2) `(+ ,expr ,expr)]
-      [`(* 2 ,expr) `(+ ,expr ,expr)]
+      ;; Strength reduction. Bind the argument to a temp so the
+      ;; expression isn't evaluated twice -- the previous (+ ,expr
+      ;; ,expr) substitution silently re-ran side effects and double-
+      ;; computed even pure expressions. The optimizer runs after the
+      ;; rewriter, so we emit a lambda application directly rather
+      ;; than a let form (which would never be rewritten).
+      [`(* ,e 2)
+       (let ([t (gensym '$mul2)])
+         `((lambda (,t) (+ ,t ,t)) ,e))]
+      [`(* 2 ,e)
+       (let ([t (gensym '$mul2)])
+         `((lambda (,t) (+ ,t ,t)) ,e))]
 
       ;; Boolean short-circuits
       [`(and #f ,_) #f]

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -131,6 +131,13 @@
     ;; If optimizations
     [`(if #t ,conseq ,_) conseq]
     [`(if #f ,_ ,alt) alt]
+    ;; Identical branches: collapse to just the branch when the test
+    ;; is pure, or to (begin test branch) when it isn't (to preserve
+    ;; the test's side effects). Constant folding routinely produces
+    ;; this shape via cascades like (if t (+ 1 2) 3) -> (if t 3 3).
+    [`(if ,test ,c ,a)
+     #:when (equal? c a)
+     (if (pure? test) c (list 'begin test c))]
 
     ;; Begin optimizations
     [`(begin) #f]

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -118,6 +118,15 @@
     ;; rule below subsumes the (not #t) / (not #f) cases.
     [`(not ,v) #:when (literal-truthy-known? v) (not v)]
     [`(not (quote ,d)) (not d)]
+    ;; (not (not x)) -> x, but only when x is provably boolean. For a
+    ;; non-boolean x the original form coerces to a boolean while x
+    ;; itself doesn't: (not (not 5)) is #t, 5 is 5. We don't have a
+    ;; full type analyzer, so the conservative test is "x is a
+    ;; boolean literal or a call to a primitive whose return type is
+    ;; boolean."
+    [`(not (not ,x))
+     #:when (returns-boolean? x)
+     x]
 
     ;; Identity optimizations
     [`(+ ,e 0) e]
@@ -127,6 +136,14 @@
     [`(* 1 ,e) e]
     [`(* ,e 0) 0]
     [`(* 0 ,e) 0]
+    ;; Single-argument arithmetic with identity element: (+ x) and
+    ;; (* x) just return x. The variadic-all-literal rules above
+    ;; handle (+) and (+ 5), but (+ x) with a non-literal needs its
+    ;; own clause.
+    [`(+ ,e) e]
+    [`(* ,e) e]
+    ;; Division by 1 (the multiplicative identity).
+    [`(/ ,e 1) e]
 
     ;; If optimizations
     [`(if #t ,conseq ,_) conseq]
@@ -294,6 +311,31 @@
 ;; not interned-identity-comparable, so they're only safe for equal?.
 (define (self-evaluating-literal? x)
   (or (number? x) (boolean? x) (char? x) (string? x)))
+
+;; VM primitives whose return type is always boolean. Used by the
+;; (not (not x)) -> x identity to confirm x is itself boolean and the
+;; coercion is observably a no-op.
+(define boolean-return-set
+  (let ([h (make-hash)])
+    (for ([p (in-list
+              '(not eq? eqv? equal?
+                = /= < <= > >= zero?
+                null? pair? list? boolean? number? integer?
+                rational? real? complex? exact? inexact?
+                procedure? symbol? string? char? port?
+                input-port? output-port? char-ready? eof-object?))])
+      (hash-set! h p #t))
+    h))
+
+(define (returns-boolean? expr)
+  (cond
+    [(boolean? expr) #t]
+    [(not (pair? expr)) #f]
+    [(eq? (car expr) 'quote) #f]
+    [(and (symbol? (car expr))
+          (hash-ref boolean-return-set (car expr) #f))
+     #t]
+    [else #f]))
 
 ;; ============================================================================
 ;; Beta-reduction of let bindings

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -135,6 +135,22 @@
     ;; Begin optimizations
     [`(begin) #f]
     [`(begin ,e) e]
+    ;; Flatten nested begins. (begin a (begin b c) d) -> (begin a b c d).
+    ;; Each nested begin would otherwise cost one expression-table slot
+    ;; and one form-ref indirection at runtime; collapsing to a single
+    ;; inline form saves both.
+    [(list 'begin es ...)
+     #:when (ormap (lambda (e) (and (pair? e) (eq? (car e) 'begin))) es)
+     (let ([flat (apply append
+                        (map (lambda (e)
+                               (if (and (pair? e) (eq? (car e) 'begin))
+                                   (cdr e)
+                                   (list e)))
+                             es))])
+       (cond
+         [(null? flat) #f]
+         [(= (length flat) 1) (car flat)]
+         [else (cons 'begin flat)]))]
     ;; Drop pure non-final expressions: their values are discarded
     ;; and they can't be observed. The final expression's value is
     ;; the begin's value and must be kept even when pure.

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -206,8 +206,36 @@
                  (self-evaluating-literal? b))
      (equal? a b)]
 
+    ;; (apply f arg1 ... '(elem1 elem2 ...)) -> (f arg1 ... elem1 elem2 ...)
+    ;; Removes the runtime apply-machinery dispatch and the temporary
+    ;; argument-list allocation. Only fires when the final argument is
+    ;; a quoted proper-list literal; elements that are not self-
+    ;; evaluating get re-wrapped in (quote ...) so the result preserves
+    ;; the original value semantics.
+    [(list 'apply f rest ...)
+     #:when (and (not (null? rest))
+                 (let ([last-arg (last rest)])
+                   (and (pair? last-arg)
+                        (eq? (car last-arg) 'quote)
+                        (= (length last-arg) 2)
+                        (list? (cadr last-arg)))))
+     (let* ([prefix (drop-right rest 1)]
+            [tail (cadr (last rest))])
+       (cons f (append prefix (map maybe-quote-elem tail))))]
+
     ;; No rule matched.
     [else expr]))
+
+;; Re-attach a quote to a value unless it's self-evaluating. Used when
+;; splicing the elements of a quoted-list argument into a call -- a
+;; symbol becomes a variable reference if left bare.
+(define (maybe-quote-elem v)
+  (cond
+    [(number? v) v]
+    [(boolean? v) v]
+    [(char? v) v]
+    [(string? v) v]
+    [else (list 'quote v)]))
 
 ;; ============================================================================
 ;; Predicates supporting pure-builtin folding

--- a/languages/scheme-racket/optimizer.rkt
+++ b/languages/scheme-racket/optimizer.rkt
@@ -10,7 +10,8 @@
 
 (provide optimize-expr
          enable-optimizations
-         optimization-level)
+         optimization-level
+         pure?)
 
 ;; Optimization parameters
 (define enable-optimizations (make-parameter #t))

--- a/languages/scheme-racket/rewriter.rkt
+++ b/languages/scheme-racket/rewriter.rkt
@@ -94,21 +94,33 @@
 (define-rewriter (even? expr)
   `(= (remainder ,(cadr expr) 2) 0))
 
-;; Absolute value
+;; Absolute value. Bind the argument to a temp first -- otherwise the
+;; argument expression is duplicated three times in the template,
+;; which silently re-runs side effects and wastes work even for pure
+;; values.
 (define-rewriter (abs expr)
-  (let ([x (cadr expr)])
-    `(if (< ,x 0) (- ,x) ,x)))
+  (let ([x (cadr expr)]
+        [t (gensym '$abs)])
+    `(let ((,t ,x))
+       (if (< ,t 0) (- ,t) ,t))))
 
-;; Max/min (binary for now)
+;; Max/min (binary for now). Same fix as abs: each argument is used
+;; twice in the if-template, so we bind first.
 (define-rewriter (max expr)
   (let ([a (cadr expr)]
-        [b (caddr expr)])
-    `(if (> ,a ,b) ,a ,b)))
+        [b (caddr expr)]
+        [ta (gensym '$max-a)]
+        [tb (gensym '$max-b)])
+    `(let ((,ta ,a) (,tb ,b))
+       (if (> ,ta ,tb) ,ta ,tb))))
 
 (define-rewriter (min expr)
   (let ([a (cadr expr)]
-        [b (caddr expr)])
-    `(if (< ,a ,b) ,a ,b)))
+        [b (caddr expr)]
+        [ta (gensym '$min-a)]
+        [tb (gensym '$min-b)])
+    `(let ((,ta ,a) (,tb ,b))
+       (if (< ,ta ,tb) ,ta ,tb))))
 
 ;; I/O
 (define-rewriter (newline expr)

--- a/languages/scheme-racket/rewriter.rkt
+++ b/languages/scheme-racket/rewriter.rkt
@@ -886,7 +886,17 @@
          ;; Depth 0: splice the list
          (if (null? (cdr expr))
              (cadar expr)  ; Just the spliced list (no tail)
-             (list 'append (cadar expr) (expand-quasiquote (cdr expr) depth)))
+             ;; Fold (append '(a b) '(c d)) -> '(a b c d) when both
+             ;; the spliced value and the expanded tail are quoted
+             ;; proper-list literals. Otherwise emit the runtime
+             ;; append. Item #18: keeps fully-static quasi-quotes
+             ;; from generating a runtime append call.
+             (let ([splice (cadar expr)]
+                   [tail-exp (expand-quasiquote (cdr expr) depth)])
+               (if (and (quoted-list-literal? splice)
+                        (quoted-list-literal? tail-exp))
+                   (list 'quote (append (cadr splice) (cadr tail-exp)))
+                   (list 'append splice tail-exp))))
          ;; Depth > 0: keep the unquote-splicing, but recurse with decreased depth
          (let ([head-expanded (list 'list
                                    (list 'quote 'unquote-splicing)
@@ -918,3 +928,13 @@
          ;; Default: cons
          [else
           (list 'cons head tail)]))]))
+
+;; True iff `expr` is a (quote DATUM) form where DATUM is a proper
+;; list (possibly empty). Used by the quasiquote append-fold above
+;; to decide when (append SPLICE TAIL) can be replaced with a single
+;; (quote ...) literal.
+(define (quoted-list-literal? expr)
+  (and (pair? expr)
+       (eq? (car expr) 'quote)
+       (= (length expr) 2)
+       (list? (cadr expr))))

--- a/languages/scheme-racket/rewriter.rkt
+++ b/languages/scheme-racket/rewriter.rkt
@@ -6,6 +6,8 @@
 ;; Implements rewrite rules similar to scheme-lib.lisp
 ;; Transforms R5RS convenience forms into VM primitives
 
+(require "optimizer.rkt")  ; opt-note-fire! for letrec-to-let trace
+
 (provide rewrite-expr
          define-rewriter
          rewriters
@@ -389,13 +391,17 @@
       [else
        (let* ([vars (map car bindings)]
               [vals (map cadr bindings)])
-         (if (ormap (lambda (v) (letrec-refs-any? v vars)) vals)
-             ;; Real recursion -- need the dummy-#f + set! dance.
-             `(let ,(map (lambda (v) `(,v #f)) vars)
-                ,@(map (lambda (v val) `(set! ,v ,val)) vars vals)
-                ,@body)
-             ;; No cross-references -- plain let is equivalent.
-             `(let ,bindings ,@body)))])))
+         (cond
+           [(ormap (lambda (v) (letrec-refs-any? v vars)) vals)
+            ;; Real recursion -- need the dummy-#f + set! dance.
+            `(let ,(map (lambda (v) `(,v #f)) vars)
+               ,@(map (lambda (v val) `(set! ,v ,val)) vars vals)
+               ,@body)]
+           [else
+            ;; No cross-references -- plain let is equivalent.
+            (let ([collapsed `(let ,bindings ,@body)])
+              (opt-note-fire! 'letrec-to-let expr collapsed)
+              collapsed)]))])))
 
 ;; True iff `expr` has a free reference to any name in `targets`,
 ;; respecting lambda formal shadowing and quote opacity.

--- a/languages/scheme-racket/rewriter.rkt
+++ b/languages/scheme-racket/rewriter.rkt
@@ -362,25 +362,64 @@
               ;; More bindings
               `(let (,first-binding) (let* ,rest-bindings ,@body)))))))
 
-;; letrec: Bind mutually recursive functions
-;; R5RS semantics: variables bound first (to undefined), then initialized
-;; (letrec ((var val)...) body...)
-;; => (let ((var #f)...) (set! var val)... body...)
+;; letrec: Bind mutually recursive functions.
+;;
+;; R5RS semantics: variables bound first (to undefined), then initialized.
+;; The general expansion is the dummy-#f + set! dance:
+;;
+;;   (letrec ((var val)...) body...)
+;;     ===>
+;;   (let ((var #f)...) (set! var val)... body...)
+;;
+;; That set! pattern is needed only when at least one val expression
+;; refers to one of the let-bound names (i.e. real recursion or
+;; mutual recursion). When no val references any sibling, plain let
+;; is semantically equivalent and avoids the box rewrite that the
+;; set! pattern triggers for any var that ends up captured by an
+;; inner lambda.
 (define-rewriter (letrec expr)
   (let ([bindings (cadr expr)]
         [body (cddr expr)])
-    (if (null? bindings)
-        ;; (letrec () body...) => (begin body...)
-        (if (= (length body) 1)
-            (car body)
-            `(begin ,@body))
-        ;; (letrec ((var val)...) body...)
-        ;; => (let ((var #f)...) (set! var val)... body...)
-        (let ([vars (map car bindings)]
+    (cond
+      ;; (letrec () body...) => (begin body...)
+      [(null? bindings)
+       (if (= (length body) 1)
+           (car body)
+           `(begin ,@body))]
+      [else
+       (let* ([vars (map car bindings)]
               [vals (map cadr bindings)])
-          `(let ,(map (lambda (v) `(,v #f)) vars)
-             ,@(map (lambda (v val) `(set! ,v ,val)) vars vals)
-             ,@body)))))
+         (if (ormap (lambda (v) (letrec-refs-any? v vars)) vals)
+             ;; Real recursion -- need the dummy-#f + set! dance.
+             `(let ,(map (lambda (v) `(,v #f)) vars)
+                ,@(map (lambda (v val) `(set! ,v ,val)) vars vals)
+                ,@body)
+             ;; No cross-references -- plain let is equivalent.
+             `(let ,bindings ,@body)))])))
+
+;; True iff `expr` has a free reference to any name in `targets`,
+;; respecting lambda formal shadowing and quote opacity.
+(define (letrec-refs-any? expr targets)
+  (cond
+    [(symbol? expr) (and (member expr targets) #t)]
+    [(not (pair? expr)) #f]
+    [(eq? (car expr) 'quote) #f]
+    [(and (eq? (car expr) 'lambda) (>= (length expr) 3))
+     (let* ([formals (cadr expr)]
+            [bound (letrec-formals->list formals)]
+            [active (filter (lambda (t) (not (member t bound))) targets)])
+       (and (not (null? active))
+            (ormap (lambda (e) (letrec-refs-any? e active)) (cddr expr))))]
+    [else
+     (ormap (lambda (e) (letrec-refs-any? e targets)) expr)]))
+
+(define (letrec-formals->list formals)
+  (cond
+    [(null? formals) '()]
+    [(symbol? formals) (list formals)]
+    [(pair? formals)
+     (cons (car formals) (letrec-formals->list (cdr formals)))]
+    [else '()]))
 
 ;; do: Transform into named let with recursion
 (define-rewriter (do expr)

--- a/languages/scheme-racket/tests/test-dead-define.rkt
+++ b/languages/scheme-racket/tests/test-dead-define.rkt
@@ -1,0 +1,116 @@
+#lang racket
+
+;; VeloxVM Racket Compiler - Dead Define Elimination Tests
+;; Copyright (c) 2025, RISE Research Institutes of Sweden AB
+
+(require rackunit
+         "../dead-define.rkt")
+
+;; ============================================================================
+;; Unreferenced define with a pure value is dropped entirely
+;; ============================================================================
+
+(check-equal? (eliminate-dead-defines
+                '((define dead-helper (lambda (x) (* x x)))
+                  (define live 5)
+                  (+ live live)))
+              '((define live 5)
+                (+ live live))
+              "dead helper with lambda value (pure) is dropped")
+
+(check-equal? (eliminate-dead-defines
+                '((define unused 42)
+                  (foo)))
+              '((foo))
+              "dead numeric constant is dropped")
+
+;; ============================================================================
+;; Unreferenced define with an impure value: keep the value, drop the binding
+;; ============================================================================
+
+(check-equal? (eliminate-dead-defines
+                '((define dead (display "side effect"))
+                  (foo)))
+              '((display "side effect")
+                (foo))
+              "dead binding with impure value: keep the value")
+
+;; ============================================================================
+;; Function shorthand whose name is referenced -- keep
+;; ============================================================================
+
+(check-equal? (eliminate-dead-defines
+                '((define (square x) (* x x))
+                  (square 5)))
+              '((define (square x) (* x x))
+                (square 5))
+              "referenced function shorthand is kept")
+
+;; ============================================================================
+;; Transitive deadness: helper used only by a dead define
+;; ============================================================================
+
+(check-equal? (eliminate-dead-defines
+                '((define helper (lambda (x) (+ x 1)))
+                  (define wrapper (lambda (x) (helper x)))
+                  ;; nothing references wrapper
+                  ))
+              '()
+              "helper and wrapper both reaped via iteration to fixpoint")
+
+;; ============================================================================
+;; Lambda formal shadows the outer name: top-level x is genuinely unused
+;; ============================================================================
+
+(check-equal? (eliminate-dead-defines
+                '((define x 5)
+                  (define (f x) (* x x))
+                  (f 10)))
+              '((define (f x) (* x x))
+                (f 10))
+              "top-level x not kept alive by f's parameter x (shadow check)")
+
+;; ============================================================================
+;; set! on a binding counts as a reference (the set! would otherwise fail)
+;; ============================================================================
+
+(check-equal? (eliminate-dead-defines
+                '((define counter 0)
+                  (set! counter (+ counter 1))))
+              '((define counter 0)
+                (set! counter (+ counter 1)))
+              "set!'d top-level binding is kept")
+
+;; ============================================================================
+;; Non-define top-level forms pass through unchanged
+;; ============================================================================
+
+(check-equal? (eliminate-dead-defines
+                '((display "hello")
+                  (+ 1 2)
+                  (foo)))
+              '((display "hello")
+                (+ 1 2)
+                (foo))
+              "non-define top-level forms preserved")
+
+;; ============================================================================
+;; Quoted reference doesn't count
+;; ============================================================================
+
+(check-equal? (eliminate-dead-defines
+                '((define dead 5)
+                  (quote dead)
+                  (foo)))
+              '((quote dead)
+                (foo))
+              "(quote NAME) is a literal symbol, not a reference to the binding")
+
+;; ============================================================================
+;; Self-recursive define is kept (the self-reference counts as a use)
+;; ============================================================================
+
+(check-equal? (eliminate-dead-defines
+                '((define (loop) (loop))))
+              '((define (loop) (loop)))
+              "self-recursive function: own body references its name (conservative)")

--- a/languages/scheme-racket/tests/test-optimizer.rkt
+++ b/languages/scheme-racket/tests/test-optimizer.rkt
@@ -174,12 +174,120 @@
   ;; ============================================================================
 
   (check-equal? (optimize-expr '((lambda (x) (eq? x 'a)) 'a))
-                '(eq? 'a 'a)
-                "Quoted symbol literal inlined")
+                #t
+                "Quoted symbol literal inlined and eq? folded all the way")
 
   (check-equal? (optimize-expr '((lambda (x) (null? x)) '()))
                 '(null? '())
-                "Quoted empty list literal inlined"))
+                "Quoted empty list literal inlined (null? not folded -- not a fold target)")
+
+  ;; ============================================================================
+  ;; Pure-builtin folding (item #7)
+  ;; ============================================================================
+
+  ;; length on a quoted list
+  (check-equal? (optimize-expr '(length (quote (1 2 3)))) 3
+                "(length '(1 2 3)) folds to 3")
+  (check-equal? (optimize-expr '(length (quote ()))) 0
+                "(length '()) folds to 0")
+  (check-equal? (optimize-expr '(length x)) '(length x)
+                "Variable arg: length isn't folded")
+
+  ;; string-length
+  (check-equal? (optimize-expr '(string-length "hello")) 5
+                "(string-length \"hello\") folds to 5")
+  (check-equal? (optimize-expr '(string-length "")) 0
+                "(string-length \"\") folds to 0")
+  (check-equal? (optimize-expr '(string-length x)) '(string-length x)
+                "Variable arg: string-length isn't folded")
+
+  ;; string-append (variadic)
+  (check-equal? (optimize-expr '(string-append "foo" "bar")) "foobar"
+                "binary string-append folds")
+  (check-equal? (optimize-expr '(string-append "a" "b" "c" "d")) "abcd"
+                "4-ary string-append folds")
+  (check-equal? (optimize-expr '(string-append)) ""
+                "zero-arg string-append folds to empty string")
+  (check-equal? (optimize-expr '(string-append "hi")) "hi"
+                "unary string-append is the identity")
+  (check-equal? (optimize-expr '(string-append "a" x "b"))
+                '(string-append "a" x "b")
+                "non-string in the middle: don't fold")
+
+  ;; char<->integer
+  (check-equal? (optimize-expr '(char->integer #\A)) 65
+                "(char->integer #\\A) folds to 65")
+  (check-equal? (optimize-expr '(integer->char 65)) #\A
+                "(integer->char 65) folds to #\\A")
+  (check-equal? (optimize-expr '(integer->char 300))
+                '(integer->char 300)
+                "out-of-VM-range codepoint: don't fold (VM stores chars as uint8_t)")
+  (check-equal? (optimize-expr '(integer->char -1))
+                '(integer->char -1)
+                "negative codepoint: don't fold")
+
+  ;; string->symbol
+  (check-equal? (optimize-expr '(string->symbol "foo")) ''foo
+                "(string->symbol \"foo\") folds to 'foo")
+
+  ;; eq? folding
+  (check-equal? (optimize-expr '(eq? (quote foo) (quote foo))) #t
+                "(eq? 'foo 'foo) folds to #t")
+  (check-equal? (optimize-expr '(eq? (quote foo) (quote bar))) #f
+                "(eq? 'foo 'bar) folds to #f")
+  (check-equal? (optimize-expr '(eq? #t #t)) #t
+                "(eq? #t #t) folds to #t")
+  (check-equal? (optimize-expr '(eq? #t #f)) #f
+                "(eq? #t #f) folds to #f")
+  (check-equal? (optimize-expr '(eq? #\a #\a)) #t
+                "(eq? #\\a #\\a) folds")
+  (check-equal? (optimize-expr '(eq? 1 1)) '(eq? 1 1)
+                "(eq? 1 1) NOT folded: eq? on numbers is implementation-defined")
+
+  ;; eqv? folding (extends eq? with numbers)
+  (check-equal? (optimize-expr '(eqv? 1 1)) #t
+                "(eqv? 1 1) folds to #t")
+  (check-equal? (optimize-expr '(eqv? 1 2)) #f
+                "(eqv? 1 2) folds to #f")
+  (check-equal? (optimize-expr '(eqv? #t #t)) #t
+                "(eqv? #t #t) folds")
+
+  ;; equal? folding
+  (check-equal? (optimize-expr '(equal? "x" "x")) #t
+                "(equal? \"x\" \"x\") folds to #t")
+  (check-equal? (optimize-expr '(equal? "x" "y")) #f
+                "(equal? \"x\" \"y\") folds to #f")
+  (check-equal? (optimize-expr '(equal? (quote (1 2)) (quote (1 2)))) #t
+                "(equal? '(1 2) '(1 2)) folds (structural)")
+  (check-equal? (optimize-expr '(equal? (quote (1 2)) (quote (1 3)))) #f
+                "(equal? '(1 2) '(1 3)) folds to #f")
+  (check-equal? (optimize-expr '(equal? 5 5)) #t
+                "(equal? 5 5) folds")
+
+  ;; not folding on non-boolean literals
+  (check-equal? (optimize-expr '(not 5)) #f
+                "(not 5) folds to #f (any number is truthy)")
+  (check-equal? (optimize-expr '(not "")) #f
+                "(not \"\") folds to #f (empty string is truthy)")
+  (check-equal? (optimize-expr '(not #\a)) #f
+                "(not #\\a) folds to #f")
+  (check-equal? (optimize-expr '(not (quote foo))) #f
+                "(not 'foo) folds to #f (any non-#f symbol is truthy)")
+  (check-equal? (optimize-expr '(not (quote ()))) #f
+                "(not '()) folds to #f (empty list is truthy in Scheme)")
+  (check-equal? (optimize-expr '(not (quote #f))) #t
+                "(not '#f) folds to #t")
+
+  ;; Cascade: folds compose via bottom-up rewrite (item #1)
+  (check-equal? (optimize-expr '(if (eq? (quote foo) (quote foo)) 'yes 'no))
+                ''yes
+                "eq? folds, then if folds, leaving just the consequent")
+  (check-equal? (optimize-expr '(+ (string-length "hello") 1))
+                6
+                "string-length folds, then arithmetic folds")
+  (check-equal? (optimize-expr '(char->integer (integer->char 65)))
+                65
+                "round-trip integer->char->integer folds end-to-end"))
 
 ;; ============================================================================
 ;; Aggressive (level 2) strength reduction binds the argument to a temp

--- a/languages/scheme-racket/tests/test-optimizer.rkt
+++ b/languages/scheme-racket/tests/test-optimizer.rkt
@@ -524,7 +524,52 @@
                 "(not (not VARIABLE)) NOT folded: coerces to boolean")
   (check-equal? (optimize-expr '(not (not 5)))
                 #t
-                "(not (not 5)): outer (not #f) -> #t via existing rules"))
+                "(not (not 5)): outer (not #f) -> #t via existing rules")
+
+  ;; ============================================================================
+  ;; and/or short-circuit folding at level 1 (item #17)
+  ;; The killer feature is trimming unreachable references so they
+  ;; don't widen closure capture sets.
+  ;; ============================================================================
+
+  ;; Empty / single-arg cases (R5RS identities).
+  (check-equal? (optimize-expr '(and)) #t "(and) -> #t")
+  (check-equal? (optimize-expr '(or)) #f "(or) -> #f")
+  (check-equal? (optimize-expr '(and x)) 'x "(and x) -> x")
+  (check-equal? (optimize-expr '(or x)) 'x "(or x) -> x")
+
+  ;; (and ... #f ...) with no impure prefix: collapses to #f, killing
+  ;; references in the tail.
+  (check-equal? (optimize-expr '(and #f (foo) (bar))) #f
+                "(and #f ...) drops the tail")
+  (check-equal? (optimize-expr '(and (+ 1 2) #f some-helper))
+                #f
+                "(and pure #f ...): pure prefix dropped, tail dropped")
+
+  ;; Impure prefix preserved in a begin.
+  (check-equal? (optimize-expr '(and (display "x") #f (foo)))
+                '(begin (display "x") #f)
+                "impure prefix wrapped in begin before #f")
+
+  ;; (or TRUTHY-LIT ...): rest dropped.
+  (check-equal? (optimize-expr '(or #t (foo) (bar))) #t
+                "(or #t ...) drops the tail")
+  (check-equal? (optimize-expr '(or 5 (foo))) 5
+                "(or 5 ...) returns 5 (numbers are truthy)")
+  (check-equal? (optimize-expr '(or "hi" (foo))) "hi"
+                "(or \"hi\" ...) returns \"hi\"")
+
+  ;; (or X) without trailing args: just the arg.
+  (check-equal? (optimize-expr '(or some-var)) 'some-var
+                "single-arg or returns the arg")
+
+  ;; No fold when there's no determining literal.
+  (check-equal? (optimize-expr '(and x y z)) '(and x y z)
+                "no #f in and: unchanged")
+  (check-equal? (optimize-expr '(or x y)) '(or x y)
+                "no truthy literal at head of or: unchanged")
+  (check-equal? (optimize-expr '(or #f x y)) '(or #f x y)
+                "(or #f ...) is NOT unconditionally foldable -- first arg might be needed"))
 
 ;; ============================================================================
 ;; Aggressive (level 2) strength reduction binds the argument to a temp

--- a/languages/scheme-racket/tests/test-optimizer.rkt
+++ b/languages/scheme-racket/tests/test-optimizer.rkt
@@ -1,0 +1,104 @@
+#lang racket
+
+;; VeloxVM Racket Compiler - Optimizer Tests
+;; Copyright (c) 2025, RISE Research Institutes of Sweden AB
+
+(require rackunit
+         "../optimizer.rkt")
+
+(parameterize ([optimization-level 1])
+
+  ;; ============================================================================
+  ;; Bottom-up / fixpoint folding (the case that motivated post-order)
+  ;; ============================================================================
+
+  (check-equal? (optimize-expr '(+ (- 3 1) 4)) 6
+                "Outer + folds after inner - is folded")
+
+  (check-equal? (optimize-expr '(* (+ 1 2) (- 5 1))) 12
+                "Both children fold, then outer *")
+
+  (check-equal? (optimize-expr '(+ (+ (+ 1 2) 3) 4)) 10
+                "Deeply nested binary + collapses end-to-end")
+
+  (check-equal? (optimize-expr '(if (= 1 1) 'a 'b)) ''a
+                "if folds after its test folds")
+
+  (check-equal? (optimize-expr '(if (= 1 2) 'a 'b)) ''b
+                "if false-branch via folded test")
+
+  (check-equal? (optimize-expr '(not (= 1 1))) #f
+                "Chained rule firing: (= 1 1) -> #t, then (not #t) -> #f")
+
+  (check-equal? (optimize-expr '(* (+ 0 5) 1)) 5
+                "Identity rules compose with arithmetic folding")
+
+  ;; ============================================================================
+  ;; Existing rules still work (regression coverage)
+  ;; ============================================================================
+
+  (check-equal? (optimize-expr '(+ 2 3)) 5
+                "Simple constant folding")
+
+  (check-equal? (optimize-expr '(+ x 0)) 'x
+                "(+ x 0) identity")
+
+  (check-equal? (optimize-expr '(* x 0)) 0
+                "(* x 0) zero")
+
+  (check-equal? (optimize-expr '(if #t 'yes 'no)) ''yes
+                "(if #t ...) literal folding")
+
+  (check-equal? (optimize-expr '(begin)) #f
+                "Empty begin")
+
+  (check-equal? (optimize-expr '(begin 42)) 42
+                "Single-form begin")
+
+  ;; ============================================================================
+  ;; Quote opacity (must not fold inside quoted data, R5RS)
+  ;; ============================================================================
+
+  (check-equal? (optimize-expr '(quote (+ 1 2))) '(quote (+ 1 2))
+                "Do not fold inside quoted lists")
+
+  (check-equal? (optimize-expr '(quote (if #t a b))) '(quote (if #t a b))
+                "Do not fold special forms inside quote")
+
+  ;; ============================================================================
+  ;; Lambda and define recurse only into bodies
+  ;; ============================================================================
+
+  (check-equal? (optimize-expr '(lambda (x) (+ 1 2)))
+                '(lambda (x) 3)
+                "Lambda body is optimized")
+
+  (check-equal? (optimize-expr '(lambda (x . rest) (+ 1 2)))
+                '(lambda (x . rest) 3)
+                "Variadic lambda formals preserved")
+
+  (check-equal? (optimize-expr '(define (f x) (+ (- 3 1) x)))
+                '(define (f x) (+ 2 x))
+                "Define-shorthand body optimized; (+ 2 x) not foldable")
+
+  ;; ============================================================================
+  ;; Don't fold on non-numeric arguments
+  ;; ============================================================================
+
+  (check-equal? (optimize-expr '(+ x 3)) '(+ x 3)
+                "Won't fold when one operand is a variable")
+
+  (check-equal? (optimize-expr '(/ 10 0)) '(/ 10 0)
+                "Don't fold division by zero literal")
+
+  ;; ============================================================================
+  ;; Optimization disabled
+  ;; ============================================================================
+
+  (parameterize ([enable-optimizations #f])
+    (check-equal? (optimize-expr '(+ (- 3 1) 4)) '(+ (- 3 1) 4)
+                  "No folding when optimizations disabled"))
+
+  (parameterize ([optimization-level 0])
+    (check-equal? (optimize-expr '(+ 2 3)) '(+ 2 3)
+                  "No folding at level 0")))

--- a/languages/scheme-racket/tests/test-optimizer.rkt
+++ b/languages/scheme-racket/tests/test-optimizer.rkt
@@ -101,4 +101,82 @@
 
   (parameterize ([optimization-level 0])
     (check-equal? (optimize-expr '(+ 2 3)) '(+ 2 3)
-                  "No folding at level 0")))
+                  "No folding at level 0"))
+
+  ;; ============================================================================
+  ;; Beta-reduce single-use let bindings
+  ;; (let rewriter has already turned (let ((x v)) body) into
+  ;;  ((lambda (x) body) v) by the time the optimizer sees it.)
+  ;; ============================================================================
+
+  (check-equal? (optimize-expr '((lambda (x) (+ x 1)) 5)) 6
+                "Numeric literal inlined, then (+ 5 1) folds")
+
+  (check-equal? (optimize-expr '((lambda (x) (+ x x)) 5)) 10
+                "Literal inlined at multiple use sites")
+
+  (check-equal? (optimize-expr '((lambda (x) (g x x)) 7))
+                '(g 7 7)
+                "Literal inlined twice into a non-foldable call")
+
+  (check-equal? (optimize-expr '((lambda (flag) (if flag 'yes 'no)) #t))
+                ''yes
+                "Boolean inline + if folding")
+
+  (check-equal? (optimize-expr '((lambda (x y) (+ x y)) 5 10)) 15
+                "Multi-binding lambda: both literals inlined, then folded")
+
+  (check-equal? (optimize-expr '((lambda (x y) (+ x y)) 5 (g)))
+                '((lambda (y) (+ 5 y)) (g))
+                "Partial inline: literal x inlined, non-literal y kept")
+
+  (check-equal? (optimize-expr '((lambda (x) (begin (set! x 6) x)) 5))
+                '((lambda (x) (begin (set! x 6) x)) 5)
+                "set! on parameter blocks inlining")
+
+  (check-equal? (optimize-expr '((lambda (x) (g x)) (h)))
+                '((lambda (x) (g x)) (h))
+                "Non-literal value: not inlined (would change order)")
+
+  (check-equal? (optimize-expr '((lambda (x) ((lambda (y) (+ x y)) 4)) 3)) 7
+                "Nested lambda apps: cascade through both inlines and folds")
+
+  (check-equal? (optimize-expr '((lambda (x) (lambda (x) x)) 5))
+                '(lambda (x) x)
+                "Inner lambda shadows: outer x inlined, inner x stays")
+
+  ;; ============================================================================
+  ;; Variadic and arity-mismatched lambdas are left alone
+  ;; ============================================================================
+
+  (check-equal? (optimize-expr '((lambda args (length args)) 1 2 3))
+                '((lambda args (length args)) 1 2 3)
+                "Bare-symbol formals not beta-reduced")
+
+  (check-equal? (optimize-expr '((lambda (x . rest) x) 1 2 3))
+                '((lambda (x . rest) x) 1 2 3)
+                "Dotted formals not beta-reduced")
+
+  ;; ============================================================================
+  ;; Quote opacity in substitution
+  ;; ============================================================================
+
+  (check-equal? (optimize-expr '((lambda (x) '(x x x)) 5))
+                ''(x x x)
+                "Don't substitute into quoted data")
+
+  (check-equal? (optimize-expr '((lambda (x) (quote x)) 5))
+                ''x
+                "Quoted symbol stays even if name matches")
+
+  ;; ============================================================================
+  ;; Quoted-atom literals inline
+  ;; ============================================================================
+
+  (check-equal? (optimize-expr '((lambda (x) (eq? x 'a)) 'a))
+                '(eq? 'a 'a)
+                "Quoted symbol literal inlined")
+
+  (check-equal? (optimize-expr '((lambda (x) (null? x)) '()))
+                '(null? '())
+                "Quoted empty list literal inlined"))

--- a/languages/scheme-racket/tests/test-optimizer.rkt
+++ b/languages/scheme-racket/tests/test-optimizer.rkt
@@ -180,3 +180,31 @@
   (check-equal? (optimize-expr '((lambda (x) (null? x)) '()))
                 '(null? '())
                 "Quoted empty list literal inlined"))
+
+;; ============================================================================
+;; Aggressive (level 2) strength reduction binds the argument to a temp
+;; ============================================================================
+
+(parameterize ([optimization-level 2])
+  ;; (* expr 2) and (* 2 expr) should now produce a let-binding so the
+  ;; argument is evaluated only once. After the let rewriter and
+  ;; optimize-basic's beta-reduction (item #2) run on a literal arg,
+  ;; the form folds further.
+  (let ([result (optimize-expr '(* x 2))])
+    (check-pred (lambda (r)
+                  (match r
+                    [`((lambda (,t1) (+ ,t2 ,t3)) x)
+                     (and (eq? t1 t2) (eq? t1 t3))]
+                    [_ #f]))
+                result
+                "(* x 2) binds x once and uses the temp twice"))
+
+  (let ([result (optimize-expr '(* 2 x))])
+    (check-pred (lambda (r)
+                  (match r
+                    [`((lambda (,t1) (+ ,t2 ,t3)) x)
+                     (and (eq? t1 t2) (eq? t1 t3))]
+                    [_ #f]))
+                result
+                "(* 2 x) (other order) also binds x once")))
+

--- a/languages/scheme-racket/tests/test-optimizer.rkt
+++ b/languages/scheme-racket/tests/test-optimizer.rkt
@@ -490,7 +490,41 @@
   ;; (test is a bare variable, so pure; the begin disappears too.)
   (check-equal? (optimize-expr '(if test (+ 1 2) 3))
                 3
-                "arithmetic fold exposes identical branches"))
+                "arithmetic fold exposes identical branches")
+
+  ;; ============================================================================
+  ;; Identity-op holes (item #15)
+  ;; ============================================================================
+
+  ;; Division by 1 is identity.
+  (check-equal? (optimize-expr '(/ x 1)) 'x "(/ x 1) -> x")
+  (check-equal? (optimize-expr '(/ (foo) 1)) '(foo) "(/ (foo) 1) -> (foo)")
+
+  ;; Single-arg + and * with non-literal args.
+  (check-equal? (optimize-expr '(+ x)) 'x "(+ x) -> x")
+  (check-equal? (optimize-expr '(* x)) 'x "(* x) -> x")
+  (check-equal? (optimize-expr '(+ (foo))) '(foo) "(+ (foo)) -> (foo)")
+
+  ;; not-not on a boolean-returning call collapses (because the inner
+  ;; result is already boolean, the outer coercion is observably a no-op).
+  (check-equal? (optimize-expr '(not (not (= x y))))
+                '(= x y)
+                "(not (not (= x y))) -> (= x y)")
+  (check-equal? (optimize-expr '(not (not (null? x))))
+                '(null? x)
+                "(not (not (null? x))) -> (null? x)")
+  (check-equal? (optimize-expr '(not (not (eq? a b))))
+                '(eq? a b)
+                "(not (not (eq? a b))) -> (eq? a b)")
+
+  ;; not-not on a non-boolean expression: do NOT fold, the coercion
+  ;; is observable.
+  (check-equal? (optimize-expr '(not (not x)))
+                '(not (not x))
+                "(not (not VARIABLE)) NOT folded: coerces to boolean")
+  (check-equal? (optimize-expr '(not (not 5)))
+                #t
+                "(not (not 5)): outer (not #f) -> #t via existing rules"))
 
 ;; ============================================================================
 ;; Aggressive (level 2) strength reduction binds the argument to a temp

--- a/languages/scheme-racket/tests/test-optimizer.rkt
+++ b/languages/scheme-racket/tests/test-optimizer.rkt
@@ -461,7 +461,36 @@
 
   ;; Non-begin children left in place.
   (check-equal? (optimize-expr '(begin (foo) (bar))) '(begin (foo) (bar))
-                "no nested begin: rule doesn't fire"))
+                "no nested begin: rule doesn't fire")
+
+  ;; ============================================================================
+  ;; Identical-branch if (item #14)
+  ;; ============================================================================
+
+  ;; Pure test (variable reference is pure): drop the test entirely.
+  (check-equal? (optimize-expr '(if x 5 5)) 5
+                "pure test + identical branches: collapse to the branch")
+
+  ;; Impure test (unknown user procedure): keep it via begin, drop the if.
+  (check-equal? (optimize-expr '(if (foo) 5 5))
+                '(begin (foo) 5)
+                "impure test + identical branches: (begin test branch)")
+
+  ;; Pure compound test (an arithmetic call) + identical branches:
+  ;; collapse to just the branch.
+  (check-equal? (optimize-expr '(if (+ 1 2) (h) (h)))
+                '(h)
+                "pure test (arithmetic) + identical branches: just the branch")
+
+  ;; Different branches: rule does not fire.
+  (check-equal? (optimize-expr '(if x 1 2)) '(if x 1 2)
+                "different branches: unchanged")
+
+  ;; Cascade: arithmetic folds first, then identical-branch fires.
+  ;; (test is a bare variable, so pure; the begin disappears too.)
+  (check-equal? (optimize-expr '(if test (+ 1 2) 3))
+                3
+                "arithmetic fold exposes identical branches"))
 
 ;; ============================================================================
 ;; Aggressive (level 2) strength reduction binds the argument to a temp

--- a/languages/scheme-racket/tests/test-optimizer.rkt
+++ b/languages/scheme-racket/tests/test-optimizer.rkt
@@ -422,7 +422,46 @@
 
   ;; Single-arg apply (just function, no list): not the shape we touch.
   (check-equal? (optimize-expr '(apply f)) '(apply f)
-                "no list arg at all: unchanged"))
+                "no list arg at all: unchanged")
+
+  ;; ============================================================================
+  ;; Begin flattening (item #12)
+  ;; ============================================================================
+
+  ;; Simple inner-first nested begin.
+  (check-equal? (optimize-expr '(begin (begin (display "a") (display "b")) (display "c")))
+                '(begin (display "a") (display "b") (display "c"))
+                "(begin (begin a b) c) -> (begin a b c)")
+
+  ;; Inner-middle nested begin: order preserved.
+  (check-equal? (optimize-expr '(begin (display "a") (begin (display "b") (display "c")) (display "d")))
+                '(begin (display "a") (display "b") (display "c") (display "d"))
+                "(begin a (begin b c) d) -> (begin a b c d)")
+
+  ;; Two adjacent nested begins.
+  (check-equal? (optimize-expr '(begin (begin (display "a") (display "b"))
+                                       (begin (display "c") (display "d"))))
+                '(begin (display "a") (display "b") (display "c") (display "d"))
+                "two adjacent nested begins both flatten")
+
+  ;; Deeply nested.
+  (check-equal? (optimize-expr '(begin (begin (begin (display "x")))))
+                '(display "x")
+                "triple-nested begin collapses to its single contents")
+
+  ;; Empty inner begin (folds to #f, then pure-drop removes the #f).
+  (check-equal? (optimize-expr '(begin (begin) (display "x")))
+                '(display "x")
+                "empty inner begin collapses to #f, then pure-drop removes it")
+
+  ;; Flatten + pure-drop cascade.
+  (check-equal? (optimize-expr '(begin (begin (+ 1 2) (display "x")) (+ 3 4)))
+                '(begin (display "x") 7)
+                "nested begin flattens, then pure-drop and arithmetic fold cascade")
+
+  ;; Non-begin children left in place.
+  (check-equal? (optimize-expr '(begin (foo) (bar))) '(begin (foo) (bar))
+                "no nested begin: rule doesn't fire"))
 
 ;; ============================================================================
 ;; Aggressive (level 2) strength reduction binds the argument to a temp

--- a/languages/scheme-racket/tests/test-optimizer.rkt
+++ b/languages/scheme-racket/tests/test-optimizer.rkt
@@ -287,7 +287,81 @@
                 "string-length folds, then arithmetic folds")
   (check-equal? (optimize-expr '(char->integer (integer->char 65)))
                 65
-                "round-trip integer->char->integer folds end-to-end"))
+                "round-trip integer->char->integer folds end-to-end")
+
+  ;; ============================================================================
+  ;; N-ary arithmetic folding (item #8)
+  ;; ============================================================================
+
+  (check-equal? (optimize-expr '(+ 1 2 3))    6 "ternary + folds")
+  (check-equal? (optimize-expr '(+ 1 2 3 4))  10 "4-ary + folds")
+  (check-equal? (optimize-expr '(+))          0 "(+) folds to 0")
+  (check-equal? (optimize-expr '(+ 7))        7 "single-arg + folds to the arg")
+  (check-equal? (optimize-expr '(* 2 3 4))    24 "ternary * folds")
+  (check-equal? (optimize-expr '(*))          1 "(*) folds to 1")
+  (check-equal? (optimize-expr '(- 10 3 2))   5 "ternary - (left-assoc) folds")
+  (check-equal? (optimize-expr '(- 5))        -5 "single-arg - negates")
+  (check-equal? (optimize-expr '(/ 100 5 2))  10 "ternary / (left-assoc) folds")
+
+  ;; Mixed literal/variable: not folded
+  (check-equal? (optimize-expr '(+ 1 x 2))    '(+ 1 x 2) "non-literal in middle: don't fold")
+  (check-equal? (optimize-expr '(* x 2 3))    '(* x 2 3) "non-literal head: don't fold")
+
+  ;; Don't fold division by zero
+  (check-equal? (optimize-expr '(/ 100 0))    '(/ 100 0) "binary div-by-zero: don't fold")
+  (check-equal? (optimize-expr '(/ 100 5 0))  '(/ 100 5 0) "trailing zero divisor: don't fold")
+  ;; A leading zero numerator is fine (0 divided by anything non-zero is 0).
+  (check-equal? (optimize-expr '(/ 0 5 2))    0 "zero numerator with non-zero divisors: folds to 0")
+
+  ;; N-ary comparisons
+  (check-equal? (optimize-expr '(< 1 2 3))    #t "ascending < chain: #t")
+  (check-equal? (optimize-expr '(< 1 3 2))    #f "non-monotone <: #f")
+  (check-equal? (optimize-expr '(= 5 5 5))    #t "all-equal =: #t")
+  (check-equal? (optimize-expr '(>= 9 5 5))   #t ">= chain: #t")
+
+  ;; ============================================================================
+  ;; Through-let folding (cascade via beta + arithmetic)
+  ;; ============================================================================
+
+  (check-equal? (optimize-expr '((lambda (x) (+ x 1)) 5)) 6
+                "(let ((x 5)) (+ x 1)) folds to 6 via beta + fold")
+
+  (check-equal? (optimize-expr '((lambda (x y) (+ x y 1)) 2 3)) 6
+                "(let ((x 2) (y 3)) (+ x y 1)) cascades")
+
+  ;; ============================================================================
+  ;; Begin: drop pure non-final expressions
+  ;; ============================================================================
+
+  ;; Pure atoms in non-final position are dropped.
+  (check-equal? (optimize-expr '(begin 1 2 3)) 3
+                "(begin 1 2 3) -> 3 (all-pure -> just the last expr)")
+
+  ;; Pure-by-primitives expressions are dropped. The (+ 1 2) and
+  ;; (+ 3 4) also fold via the arithmetic rule, so the final form
+  ;; preserves only the impure display and the folded final value.
+  (check-equal? (optimize-expr '(begin (+ 1 2) (display "x") (+ 3 4)))
+                '(begin (display "x") 7)
+                "pure (+ 1 2) dropped; display kept; final (+ 3 4) folds to 7")
+
+  ;; Several pure non-finals all collapse out.
+  (check-equal? (optimize-expr '(begin (* 2 3) (length (quote (a b))) (foo)))
+                '(foo)
+                "all non-final exprs pure -> reduced to the impure final")
+
+  ;; All-impure: nothing dropped.
+  (check-equal? (optimize-expr '(begin (display "a") (display "b") (display "c")))
+                '(begin (display "a") (display "b") (display "c"))
+                "all-impure begin: unchanged")
+
+  ;; Final expression's purity doesn't matter; it stays as the result.
+  (check-equal? (optimize-expr '(begin (display "x") 42)) '(begin (display "x") 42)
+                "pure final value is preserved")
+
+  ;; Cascade: arithmetic folds first, then dead-code drops pure intermediates.
+  (check-equal? (optimize-expr '(begin (+ 1 2) (* 3 4) (foo)))
+                '(foo)
+                "compose folding and dead-code elimination"))
 
 ;; ============================================================================
 ;; Aggressive (level 2) strength reduction binds the argument to a temp

--- a/languages/scheme-racket/tests/test-optimizer.rkt
+++ b/languages/scheme-racket/tests/test-optimizer.rkt
@@ -361,7 +361,68 @@
   ;; Cascade: arithmetic folds first, then dead-code drops pure intermediates.
   (check-equal? (optimize-expr '(begin (+ 1 2) (* 3 4) (foo)))
                 '(foo)
-                "compose folding and dead-code elimination"))
+                "compose folding and dead-code elimination")
+
+  ;; ============================================================================
+  ;; (apply F '(...)) flattening (item #11)
+  ;; ============================================================================
+
+  ;; Basic flatten + arithmetic cascade.
+  (check-equal? (optimize-expr '(apply + '(1 2 3))) 6
+                "(apply + '(1 2 3)) flattens to (+ 1 2 3), then folds")
+
+  ;; Prefix args before the final list.
+  (check-equal? (optimize-expr '(apply + 10 '(1 2 3))) 16
+                "prefix args preserved: (apply + 10 '(1 2 3)) -> (+ 10 1 2 3) -> 16")
+
+  ;; Empty list: just (f) (or with prefix, (f prefix...)).
+  (check-equal? (optimize-expr '(apply f '())) '(f)
+                "empty list: zero-arg call")
+  (check-equal? (optimize-expr '(apply f 'a 'b '())) '(f 'a 'b)
+                "empty list with prefix args: prefix preserved")
+
+  ;; Self-evaluating elements (numbers, strings, chars, booleans):
+  ;; spliced as-is, no quote needed.
+  (check-equal? (optimize-expr '(apply f '(1 "hi" #\c #t)))
+                '(f 1 "hi" #\c #t)
+                "self-evaluating elements spliced bare")
+
+  ;; Symbol elements: re-quoted so they stay literal values, not
+  ;; variable references.
+  (check-equal? (optimize-expr '(apply f '(a b c)))
+                '(f 'a 'b 'c)
+                "symbol elements get re-quoted")
+
+  ;; Nested list element: kept quoted.
+  (check-equal? (optimize-expr '(apply f '(a (b c) d)))
+                '(f 'a '(b c) 'd)
+                "nested list element gets its quote back")
+
+  ;; Mixed: each element handled individually.
+  (check-equal? (optimize-expr '(apply f '(1 a "x" b)))
+                '(f 1 'a "x" 'b)
+                "mixed self-eval / symbol elements")
+
+  ;; Function position can be a lambda; the result is then a beta-
+  ;; reducible form and item #2 takes over.
+  (check-equal? (optimize-expr '(apply (lambda (x) (* x x)) '(5))) 25
+                "lambda in function position: cascade through beta + fold")
+
+  ;; ============================================================================
+  ;; Non-matching shapes are left alone
+  ;; ============================================================================
+
+  ;; Variable argument: not a literal list.
+  (check-equal? (optimize-expr '(apply f xs)) '(apply f xs)
+                "variable last arg: not folded")
+
+  ;; Improper list literal: leave alone (compile-quote doesn't handle it).
+  (check-equal? (optimize-expr '(apply f '(1 . 2))) '(apply f '(1 . 2))
+                "improper list literal: not folded")
+
+  ;; Single-arg apply (just function, no list): not the shape we touch.
+  (check-equal? (optimize-expr '(apply f)) '(apply f)
+                "no list arg at all: unchanged"))
 
 ;; ============================================================================
 ;; Aggressive (level 2) strength reduction binds the argument to a temp

--- a/languages/scheme-racket/tests/test-rewriter.rkt
+++ b/languages/scheme-racket/tests/test-rewriter.rkt
@@ -23,19 +23,41 @@
               '(= (remainder x 2) 0)
               "Rewrite even?")
 
-;; Test abs
-(check-equal? (rewrite-expr '(abs x))
-              '(if (< x 0) (- x) x)
-              "Rewrite abs")
+;; Test abs. The rewriter binds the argument to a temp so the
+;; expression isn't duplicated; after the let rewriter runs, the
+;; result is a single-arg lambda application.
+(let ([result (rewrite-expr '(abs x))])
+  (check-pred (lambda (r)
+                (match r
+                  [`((lambda (,t1) (if (< ,t2 0) (- ,t3) ,t4)) x)
+                   (and (eq? t1 t2) (eq? t1 t3) (eq? t1 t4))]
+                  [_ #f]))
+              result
+              "abs binds the argument once and uses the temp three times"))
 
-;; Test max/min
-(check-equal? (rewrite-expr '(max a b))
-              '(if (> a b) a b)
-              "Rewrite max")
+;; Test max/min. Both arguments bound first, then the if dispatches
+;; over the temps.
+(let ([result (rewrite-expr '(max a b))])
+  (check-pred (lambda (r)
+                (match r
+                  [`((lambda (,ta ,tb) (if (> ,ta1 ,tb1) ,ta2 ,tb2)) a b)
+                   (and (eq? ta ta1) (eq? ta ta2)
+                        (eq? tb tb1) (eq? tb tb2)
+                        (not (eq? ta tb)))]
+                  [_ #f]))
+              result
+              "max binds both args once each"))
 
-(check-equal? (rewrite-expr '(min a b))
-              '(if (< a b) a b)
-              "Rewrite min")
+(let ([result (rewrite-expr '(min a b))])
+  (check-pred (lambda (r)
+                (match r
+                  [`((lambda (,ta ,tb) (if (< ,ta1 ,tb1) ,ta2 ,tb2)) a b)
+                   (and (eq? ta ta1) (eq? ta ta2)
+                        (eq? tb tb1) (eq? tb tb2)
+                        (not (eq? ta tb)))]
+                  [_ #f]))
+              result
+              "min binds both args once each"))
 
 ;; Test I/O
 (check-equal? (rewrite-expr '(newline))
@@ -84,10 +106,18 @@
               '(< (string-compare a b) 0)
               "Rewrite string<?")
 
-;; Test nested rewriting
-(check-equal? (rewrite-expr '(+ (abs x) (max a b)))
-              '(+ (if (< x 0) (- x) x) (if (> a b) a b))
-              "Rewrite nested expressions")
+;; Test nested rewriting. abs and max each expand to a lambda
+;; application around the arg-binding temp; check the shape rather
+;; than exact symbol identity.
+(let ([result (rewrite-expr '(+ (abs x) (max a b)))])
+  (check-pred (lambda (r)
+                (match r
+                  [`(+ ((lambda (,_) (if (< ,_ 0) (- ,_) ,_)) x)
+                       ((lambda (,_ ,_) (if (> ,_ ,_) ,_ ,_)) a b))
+                   #t]
+                  [_ #f]))
+              result
+              "nested abs/max each expand to a lambda app, leaving the outer + intact"))
 
 ;; Test no rewriting for unknown forms
 (check-equal? (rewrite-expr '(unknown-form a b))

--- a/languages/scheme-racket/tests/test-rewriter.rkt
+++ b/languages/scheme-racket/tests/test-rewriter.rkt
@@ -124,4 +124,42 @@
               '(unknown-form a b)
               "Don't rewrite unknown forms")
 
+;; ============================================================================
+;; letrec: no cross-references collapses to plain let
+;; ============================================================================
+
+;; Non-recursive bindings -- letrec should become plain let, which then
+;; rewrites to a lambda application.
+(check-equal? (rewrite-expr '(letrec ((x 5) (y 10)) (+ x y)))
+              '((lambda (x y) (+ x y)) 5 10)
+              "letrec with no cross-refs becomes a plain lambda app")
+
+;; A binding whose value references its own name -- real self-recursion.
+;; Keep the dummy-#f + set! dance.
+(check-equal? (rewrite-expr '(letrec ((f (lambda (n) (f n)))) (f 0)))
+              '((lambda (f) (set! f (lambda (n) (f n))) (f 0)) #f)
+              "self-recursive letrec keeps the set! dance")
+
+;; Mutual recursion -- one binding's value references the other.
+(check-equal? (rewrite-expr '(letrec ((a (lambda () (b)))
+                                      (b (lambda () (a))))
+                               (a)))
+              '((lambda (a b)
+                  (set! a (lambda () (b)))
+                  (set! b (lambda () (a)))
+                  (a))
+                #f #f)
+              "mutual-recursive letrec keeps the set! dance")
+
+;; Free reference inside a quoted datum is NOT a real reference.
+(check-equal? (rewrite-expr '(letrec ((x 5)) (list 'x x)))
+              '((lambda (x) (list 'x x)) 5)
+              "quoted occurrence of the name doesn't count as a reference")
+
+;; Free reference inside a lambda whose formals shadow the name doesn't
+;; count either.
+(check-equal? (rewrite-expr '(letrec ((x (lambda (x) (* x 2)))) (x 5)))
+              '((lambda (x) (x 5)) (lambda (x) (* x 2)))
+              "shadowed inner lambda doesn't count as a self-reference")
+
 (displayln "All rewriter tests passed!")

--- a/languages/scheme-racket/tests/test-rewriter.rkt
+++ b/languages/scheme-racket/tests/test-rewriter.rkt
@@ -162,4 +162,29 @@
               '((lambda (x) (x 5)) (lambda (x) (* x 2)))
               "shadowed inner lambda doesn't count as a self-reference")
 
+;; ============================================================================
+;; Quasiquote append-fold (item #18)
+;; ============================================================================
+
+;; Splicing a quoted list followed by a literal tail: should fold to a
+;; single quote instead of emitting a runtime (append ...).
+(check-equal? (rewrite-expr `(quasiquote (,@'(a b) c)))
+              ''(a b c)
+              "(append '(a b) '(c)) folds to '(a b c)")
+
+;; Two adjacent splices, both of quoted lists.
+(check-equal? (rewrite-expr `(quasiquote (,@'(a b) ,@'(c d))))
+              ''(a b c d)
+              "two splices fold end-to-end")
+
+;; Splicing an empty list.
+(check-equal? (rewrite-expr `(quasiquote (,@'() x)))
+              ''(x)
+              "empty splice + literal tail folds")
+
+;; Splicing a runtime value: no fold (the append stays at runtime).
+(check-equal? (rewrite-expr `(quasiquote (,@xs c)))
+              '(append xs '(c))
+              "non-literal splice: append stays")
+
 (displayln "All rewriter tests passed!")

--- a/tests/unit-tests/vm-specific/test-arg-once.scm
+++ b/tests/unit-tests/vm-specific/test-arg-once.scm
@@ -1,0 +1,86 @@
+;; VeloxVM Unit Tests - Single argument evaluation
+;;
+;; Regression coverage for argument-duplicating rewriters in the Racket
+;; compiler. abs, max, min, and the level-2 (* x 2) strength reduction
+;; previously substituted the argument expression directly into the
+;; output template, which silently re-evaluated the expression at every
+;; substitution site -- a correctness bug for side-effecting arguments
+;; and wasted work for pure ones. They now bind the argument to a
+;; gensym temp first.
+
+(include "../unit-test-framework.scm")
+
+(test-suite "Argument-once evaluation")
+
+;; ============================================================================
+;; abs evaluates its argument exactly once
+;; ============================================================================
+
+(define abs-counter 0)
+(define (count-and-return-neg)
+  (set! abs-counter (+ abs-counter 1))
+  -7)
+
+(define abs-result (abs (count-and-return-neg)))
+(assert-equal 7 abs-result "abs of -7 -> 7")
+(assert-equal 1 abs-counter "abs evaluated its argument exactly once")
+
+;; Positive path: same single-eval guarantee.
+(set! abs-counter 0)
+(define (count-and-return-pos)
+  (set! abs-counter (+ abs-counter 1))
+  5)
+
+(define abs-pos-result (abs (count-and-return-pos)))
+(assert-equal 5 abs-pos-result "abs of 5 -> 5")
+(assert-equal 1 abs-counter "abs evaluates positive arg exactly once")
+
+;; ============================================================================
+;; max evaluates each argument exactly once
+;; ============================================================================
+
+(define max-a-count 0)
+(define max-b-count 0)
+(define (count-a-3)
+  (set! max-a-count (+ max-a-count 1))
+  3)
+(define (count-b-9)
+  (set! max-b-count (+ max-b-count 1))
+  9)
+
+(define max-result (max (count-a-3) (count-b-9)))
+(assert-equal 9 max-result "max of 3 and 9 -> 9")
+(assert-equal 1 max-a-count "max evaluates first arg exactly once")
+(assert-equal 1 max-b-count "max evaluates second arg exactly once")
+
+;; ============================================================================
+;; min evaluates each argument exactly once
+;; ============================================================================
+
+(define min-a-count 0)
+(define min-b-count 0)
+(define (count-a-4)
+  (set! min-a-count (+ min-a-count 1))
+  4)
+(define (count-b-2)
+  (set! min-b-count (+ min-b-count 1))
+  2)
+
+(define min-result (min (count-a-4) (count-b-2)))
+(assert-equal 2 min-result "min of 4 and 2 -> 2")
+(assert-equal 1 min-a-count "min evaluates first arg exactly once")
+(assert-equal 1 min-b-count "min evaluates second arg exactly once")
+
+;; ============================================================================
+;; Pure-value paths still produce correct results
+;; ============================================================================
+
+(assert-equal 5  (abs -5)      "abs of literal -5")
+(assert-equal 5  (abs 5)       "abs of literal 5")
+(assert-equal 0  (abs 0)       "abs of zero")
+(assert-equal 9  (max 3 9)     "max of literals")
+(assert-equal 9  (max 9 3)     "max of literals (other order)")
+(assert-equal 2  (min 4 2)     "min of literals")
+(assert-equal 2  (min 2 4)     "min of literals (other order)")
+
+(test-summary)


### PR DESCRIPTION
This PR adds a variety of optimizations to the Racket compiler that can be applied on Scheme code compiled for VeloxVM.