### PR TITLE
racket compiler: auto-prepend runtime-library prelude

### DIFF
--- a/languages/scheme-racket/main.rkt
+++ b/languages/scheme-racket/main.rkt
@@ -3,7 +3,8 @@
 ;; VeloxVM Racket Compiler - Main Entry Point
 ;; Copyright (c) 2025, RISE Research Institutes of Sweden AB
 
-(require "reader.rkt"
+(require racket/runtime-path
+         "reader.rkt"
          "expander.rkt"  ; Macro expansion
          "rewriter.rkt"
          "optimizer.rkt"  ; Optimizations
@@ -11,6 +12,34 @@
          "errors.rkt"     ; Error handling
          "compiler.rkt"
          "bytecode.rkt")
+
+;; Runtime-library prelude: auto-prepended to every user program so the
+;; pure-Scheme procedures shipped under runtime/ are reachable without
+;; an explicit (include ...). The dead-define pass strips any prelude
+;; binding the user program doesn't reference, so the bytecode cost is
+;; paid only for what is actually used.
+;;
+;; r7rs-lists.scm is excluded because it would redefine the primitive
+;; names assoc / member; including it in the prelude would shadow those
+;; primitives for every program. Users who want the optional-comparator
+;; form can still (include "r7rs-lists.scm") explicitly.
+(define-runtime-path prelude-dir "runtime")
+
+(define prelude-files
+  '("r7rs-numeric.scm"
+    "r7rs-strings.scm"
+    "r7rs-features.scm"
+    "r7rs-bytevectors.scm"
+    "r7rs-parameters.scm"
+    "r7rs-errors.scm"
+    "r5rs-io.scm"))
+
+;; Read once at module load; reused for every compile-string call.
+(define prelude-exprs
+  (apply append
+    (for/list ([f (in-list prelude-files)])
+      (let ([path (build-path prelude-dir f)])
+        (read-all-exprs (file->string path) path)))))
 
 (provide compile-file
          compile-string
@@ -34,7 +63,10 @@
 ;; source-file: optional path for resolving include directives
 (define (compile-string source-code [source-file #f])
   (opt-stats-reset!)
-  (let* ([exprs (read-all-exprs source-code source-file)]
+  (let* ([user-exprs (read-all-exprs source-code source-file)]
+         ;; Prepend the runtime-library prelude. Dead-define elimination
+         ;; later in the pipeline drops anything the user doesn't use.
+         [exprs (append prelude-exprs user-exprs)]
          ;; Expand macros first (handles define-syntax)
          ;; Filter out *FILTERED* sentinel values (from define-syntax)
          [expanded (filter (lambda (e) (not (eq? e *FILTERED*)))

--- a/tests/unit-tests/r7rs/test-prelude.scm
+++ b/tests/unit-tests/r7rs/test-prelude.scm
@@ -1,0 +1,63 @@
+;;; VeloxVM Unit Tests - Runtime-library prelude auto-prepend
+;;; Confirms that procedures shipped under runtime/r7rs-*.scm are
+;;; reachable from a user program WITHOUT an explicit (include ...).
+;;;
+;;; The compiler auto-prepends a fixed list of runtime files (see
+;;; languages/scheme-racket/main.rkt:prelude-files) so these names
+;;; resolve out of the box; the dead-define pass strips unused
+;;; bindings, so a program that doesn't use the prelude pays no
+;;; bytecode cost for it.
+
+(include "../unit-test-framework.scm")
+
+(test-suite "Runtime-library prelude")
+
+;; --- r7rs-numeric.scm ---------------------------------------------------
+(assert-equal 25 (square 5) "square from prelude")
+(assert-equal #t (exact-integer? 7) "exact-integer? from prelude")
+(assert-equal #f (exact-integer? 1/2) "exact-integer? rejects rational")
+(assert-equal 3 (truncate-quotient 10 3) "truncate-quotient from prelude")
+(assert-equal -4 (floor-quotient 10 -3) "floor-quotient from prelude")
+
+;; --- r7rs-strings.scm ---------------------------------------------------
+(assert-equal "ABC"
+              (string-map char-upcase "abc")
+              "string-map from prelude")
+
+;; --- r7rs-features.scm --------------------------------------------------
+(assert-equal #t (list? (features)) "features returns a list")
+
+;; --- r7rs-bytevectors.scm -----------------------------------------------
+(define bv (make-bytevector 4 0))
+(bytevector-u8-set! bv 1 200)
+(assert-equal 0   (bytevector-u8-ref bv 0) "bytevector-u8-ref default fill")
+(assert-equal 200 (bytevector-u8-ref bv 1) "bytevector-u8-ref after set!")
+(assert-equal 4   (bytevector-length bv)   "bytevector-length from prelude")
+
+;; --- r7rs-parameters.scm ------------------------------------------------
+(define p (make-parameter 10))
+(assert-equal 10 (p)    "make-parameter reads initial value")
+(p 20)
+(assert-equal 20 (p)    "make-parameter writes new value")
+
+;; --- r7rs-errors.scm ----------------------------------------------------
+;; error raises, so we must trip it inside a guard to observe the object.
+(define caught
+  (guard (e (#t e))
+    (error "boom" 1 2 3)))
+(assert-equal #t (error-object? caught)
+              "error-object? recognises error from prelude")
+(assert-equal "boom" (error-object-message caught)
+              "error-object-message from prelude")
+(assert-equal '(1 2 3) (error-object-irritants caught)
+              "error-object-irritants from prelude")
+
+;; --- r5rs-io.scm --------------------------------------------------------
+;; Only confirm the binding is reachable; the procedure itself needs a
+;; filesystem port to exercise.
+(assert-equal #t (procedure? call-with-input-file)
+              "call-with-input-file reachable from prelude")
+(assert-equal #t (procedure? call-with-output-file)
+              "call-with-output-file reachable from prelude")
+
+(test-summary)


### PR DESCRIPTION
compile-string reads the runtime/r7rs-*.scm files at module load and prepends them to every user program, so procedures like square, string-map, make-parameter, error, and the bytevector wrappers are reachable without an explicit (include ...). The dead-define pass strips unreferenced prelude bindings, so programs that don't use the prelude pay no bytecode cost.

r7rs-lists.scm is excluded -- it would shadow primitive assoc / member; users who want the optional-comparator form include it explicitly.