### PR TITLE
packet-schema: drop dead empty-chunk guard in pkt-concat-walk

### DIFF
--- a/languages/scheme/runtime/packet-schema.scm
+++ b/languages/scheme/runtime/packet-schema.scm
@@ -389,10 +389,7 @@
   (if (null? bufs)
       result
       (let ((chunk (car bufs)))
-        ;; buffer-append rejects index == dst-length even for a zero-byte
-        ;; source, so skip empty chunks rather than emit a spurious error.
-        (when (> (vector-length chunk) 0)
-          (buffer-append result pos chunk))
+        (buffer-append result pos chunk)
         (pkt-concat-walk (cdr bufs)
                          result
                          (+ pos (vector-length chunk))))))


### PR DESCRIPTION
The (when (> (vector-length chunk) 0) ...) guard around the buffer-append call was a workaround for an earlier buffer-append behaviour: a length check ran before the source-type switch and rejected index == dst-length even when the source contained zero bytes. Commit 079a14d moved the bounds check into each source-type arm, so empty chunks at the natural end-of-buffer sentinel are now accepted. The guard has no effect since that landed; remove it.

test-packet-schema and test-packet-varlen pass unchanged.