### PR TITLE
benchmarks: add GC-stress suite for adversarial allocation patterns

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,6 +24,25 @@ These benchmarks are designed to measure VM performance characteristics and vali
   around depth 40; depth 200 proves iterative mark works
 - Complementary to tree-walk.scm, which exercises a branched shape
 
+#### GC stress suite
+
+Adversarial benchmarks that each isolate a single GC cost vector for
+profiling and tuning. Pair with the per-GC pause-time instrumentation
+in `core/vm-memory.c` (gated on `VM_PAUSE_PROFILING`) to derive the
+contribution of each phase. Each non-`crash-spine` benchmark has a
+`-small` companion sized to fit the Zoul-tier (5 / 3 kB) and mid-tier
+(32 / 16 kB) heap configurations.
+
+| Benchmark                       | Isolates                                                |
+|---------------------------------|---------------------------------------------------------|
+| alloc-and-drop.scm              | Per-GC constant overhead with a near-zero live set      |
+| wide-vector.scm                 | `VECTOR` mark walk over an N-element elements array     |
+| pool-near-full.scm              | Object-pool sweep gated by the 2/3-full threshold       |
+| ext-objects.scm                 | Linear walk of `ext_object_list_head` on every GC       |
+| combined-deep-and-full.scm      | Depth + multi-root + sweep-gate stress together         |
+| shared-symtab-threads.scm       | Per-thread re-mark of the shared symbol-bindings table  |
+| crash-spine.scm                 | Recursive-marker C-stack overflow at large spine depth (no `-small` variant — the point is to crash, run on the target you want to characterise) |
+
 ### Compute
 
 **fib-recursive.scm** - Naive recursive Fibonacci, repeated

--- a/benchmarks/alloc-and-drop-small.scm
+++ b/benchmarks/alloc-and-drop-small.scm
@@ -1,0 +1,32 @@
+;; Allocate-and-drop floor (§7.6), with the dead-code fix.
+;;
+;; The previous alloc-and-drop variant had its cons calls dead-stripped
+;; by the Scheme compiler because the results were never used. This
+;; one routes each cons through a top-level set! cell so the allocation
+;; cannot be eliminated. Each iteration allocates 3 cells; previous
+;; iteration's cell becomes garbage immediately.
+
+(print "=== Allocate-and-drop floor (small) ===\n")
+
+(define iters 5000)
+(define holder1 '())
+(define holder2 '())
+(define holder3 '())
+
+(define (alloc-drop k)
+  (if (= k 0) 'done
+      (begin
+        (set! holder1 (cons k '()))
+        (set! holder2 (cons k holder1))
+        (set! holder3 (cons k (cons k '())))
+        (alloc-drop (- k 1)))))
+
+(print "Iterations: ") (print iters)
+(print " (3 cells per iter, ") (print (* iters 3)) (print " total)\n")
+
+(define t-start (time))
+(alloc-drop iters)
+(define t-end (time))
+
+(print "  elapsed: ") (print (- t-end t-start)) (print " ms\n")
+(print "Status: PASS\n")

--- a/benchmarks/alloc-and-drop.scm
+++ b/benchmarks/alloc-and-drop.scm
@@ -1,0 +1,45 @@
+;; Allocate-and-drop floor benchmark.
+;;
+;; Tight loop that allocates short-lived cons cells with no retained
+;; structure. Live set stays near zero; only the pressure loop's own
+;; cons cells are live for one instruction at a time. This isolates
+;; the GC's constant-overhead path: the always-walked roots, the
+;; allocation hash table scan over allocations.size (vm-memory.c:555),
+;; the pool ref-bitmap clear (vm-mempool.c:294-309), and the finalize-
+;; list head reads.
+;;
+;; Useful as a floor measurement: how much time is spent in GC
+;; plumbing even when there is essentially nothing to mark and nothing
+;; to sweep? Subtract from richer benchmarks to isolate live-set cost.
+
+(print "=== Allocate-and-drop floor ===\n")
+
+(define iters 200000)
+
+(define (alloc-drop k)
+  (if (= k 0) 'done
+      (begin
+        (cons k '())
+        (cons k k)
+        (cons k (cons k '()))
+        (alloc-drop (- k 1)))))
+
+(print "Running ") (print iters)
+(print " iterations of cons-and-drop (3 allocs each, ")
+(print (* iters 3)) (print " cells total)...\n")
+
+(define t-start (time))
+(alloc-drop iters)
+(define t-end (time))
+(define elapsed (- t-end t-start))
+(define total-allocations (* iters 3))
+
+(print "  elapsed: ") (print elapsed) (print " ms\n")
+(if (> elapsed 0)
+    (begin
+      (print "  rate:    ")
+      (print (* (quotient total-allocations elapsed) 1000))
+      (print " allocs/sec\n"))
+    'skip)
+
+(print "Status: PASS\n")

--- a/benchmarks/combined-deep-and-full.scm
+++ b/benchmarks/combined-deep-and-full.scm
@@ -1,0 +1,78 @@
+;; Compounded mark + sweep stress.
+;;
+;; Combines three shapes that individually live in deep-structures.scm
+;; (depth), memory-stress.scm (multiple roots), and pool-near-full.scm
+;; (sweep gate). Each GC cycle pays:
+;;   - Recursive mark on five separate spine roots
+;;   - Sweep over a pool kept above the 2/3 gate
+;; This is the "max stress" baseline for current-marker pause time.
+;; After linearization, the recursive depth cost should disappear and
+;; only the multi-root + sweep cost remain.
+;;
+;; spine-depth is set well below the ~40-frame Zoul crash point to
+;; remain portable; this benchmark measures slowdown, not crashes
+;; (see crash-spine.scm for the crash probe).
+
+(print "=== Combined: deep × multi-root × full pool ===\n")
+
+(define spine-depth 30)
+(define gc-cycles 3000)
+(define throwaway-size 300)
+
+(define (build-deep d)
+  (define (iter d acc)
+    (if (= d 0) acc (iter (- d 1) (cons d acc))))
+  (iter d '()))
+
+(define spine-a (build-deep spine-depth))
+(define spine-b (build-deep spine-depth))
+(define spine-c (build-deep spine-depth))
+(define spine-d (build-deep spine-depth))
+(define spine-e (build-deep spine-depth))
+
+;; Additional padding to push the pool above the 2/3 sweep gate on
+;; small-pool targets (Zoul). Harmless on hosts where the pool is
+;; far larger than this; the cost shows only when the gate trips.
+(define padding (build-deep 60))
+
+(print "Five spines of depth ") (print spine-depth)
+(print " + ") (print 60) (print "-cell padding\n")
+
+(define (pressure k)
+  (if (= k 0) 'done
+      (begin
+        (build-deep throwaway-size)
+        (pressure (- k 1)))))
+
+(print "Forcing GC pressure with ") (print gc-cycles)
+(print " throwaway spines of ") (print throwaway-size) (print " cells...\n")
+
+(define t-start (time))
+(pressure gc-cycles)
+(define t-end (time))
+(define elapsed (- t-end t-start))
+(define total-allocations (* gc-cycles throwaway-size))
+
+(define (depth-of lst)
+  (let loop ((l lst) (n 0))
+    (if (null? l) n (loop (cdr l) (+ n 1)))))
+
+(define ok
+  (and (= (depth-of spine-a) spine-depth)
+       (= (depth-of spine-b) spine-depth)
+       (= (depth-of spine-c) spine-depth)
+       (= (depth-of spine-d) spine-depth)
+       (= (depth-of spine-e) spine-depth)))
+
+(print "  all five spines intact: ") (print (if ok "yes" "NO")) (print "\n")
+(print "  elapsed:                ") (print elapsed) (print " ms\n")
+(if (> elapsed 0)
+    (begin
+      (print "  rate:                   ")
+      (print (* (quotient total-allocations elapsed) 1000))
+      (print " allocs/sec\n"))
+    'skip)
+
+(if ok
+    (print "Status: PASS\n")
+    (print "Status: FAIL\n"))

--- a/benchmarks/combined-small.scm
+++ b/benchmarks/combined-small.scm
@@ -1,0 +1,45 @@
+;; Combined deep × multi-root × full pool, small-tier (§7.7).
+;; 3 spines of 15 + 30-cell padding = ~75 live cells, fits Zoul pool.
+
+(print "=== Combined (small) ===\n")
+
+(define spine-depth 15)
+(define gc-cycles 3000)
+(define throwaway-size 30)
+
+(define (build-deep d)
+  (let loop ((i d) (acc '()))
+    (if (= i 0) acc (loop (- i 1) (cons i acc)))))
+
+(define spine-a (build-deep spine-depth))
+(define spine-b (build-deep spine-depth))
+(define spine-c (build-deep spine-depth))
+(define padding (build-deep 30))
+
+(print "3 spines depth ") (print spine-depth)
+(print " + 30 padding\n")
+
+(define (pressure k)
+  (if (= k 0) 'done
+      (begin
+        (build-deep throwaway-size)
+        (pressure (- k 1)))))
+
+(define t-start (time))
+(pressure gc-cycles)
+(define t-end (time))
+(define elapsed (- t-end t-start))
+
+(define (depth-of lst)
+  (let loop ((l lst) (n 0))
+    (if (null? l) n (loop (cdr l) (+ n 1)))))
+
+(define ok
+  (and (= (depth-of spine-a) spine-depth)
+       (= (depth-of spine-b) spine-depth)
+       (= (depth-of spine-c) spine-depth)))
+
+(print "  intact:  ") (print (if ok "yes" "NO")) (print "\n")
+(print "  elapsed: ") (print elapsed) (print " ms\n")
+
+(if ok (print "Status: PASS\n") (print "Status: FAIL\n"))

--- a/benchmarks/crash-spine.scm
+++ b/benchmarks/crash-spine.scm
@@ -1,0 +1,58 @@
+;; Crash probe: right-nested cons spine vs recursive marker.
+;;
+;; Builds a right-nested cons spine of `depth` cells, keeps it live,
+;; then runs allocation pressure to force GC. mark_object recurses
+;; once per cell of the spine (vm-memory.c:170-178). On targets with
+;; small native C stacks (Zoul: ~2 kB), the recursion overflows
+;; somewhere around depth 40. On POSIX (8 MB native stack), any
+;; practical depth survives -- run this on real hardware to see the
+;; effect.
+;;
+;; Use as a binary signal: did the VM complete or abort? Sweep
+;; `depth` upward across runs (60, 80, 100, 200, 500, ...) until the
+;; crash point is found.
+;;
+;; After linearization, all values of `depth` up to the live mark-
+;; bearing object count should complete successfully on every target.
+;; This file then becomes a regression test rather than a probe.
+
+(print "=== Crash-spine probe ===\n")
+
+(define depth 200)
+(define pressure-iters 200)
+(define throwaway-size 100)
+
+(define (build-deep d)
+  (define (iter d acc)
+    (if (= d 0) acc (iter (- d 1) (cons d acc))))
+  (iter d '()))
+
+(define spine (build-deep depth))
+(print "Built spine of depth ") (print depth) (print "\n")
+
+(define (pressure k)
+  (if (= k 0) 'done
+      (begin
+        (build-deep throwaway-size)
+        (pressure (- k 1)))))
+
+(print "Running ") (print pressure-iters)
+(print " pressure iterations to force GC...\n")
+
+(define t-start (time))
+(pressure pressure-iters)
+(define t-end (time))
+
+(define final-depth
+  (let loop ((l spine) (n 0))
+    (if (null? l) n (loop (cdr l) (+ n 1)))))
+
+(print "  spine depth after pressure: ") (print final-depth) (print "\n")
+(print "  expected:                   ") (print depth) (print "\n")
+(print "  elapsed:                    ") (print (- t-end t-start))
+(print " ms\n")
+
+(if (= final-depth depth)
+    (begin
+      (print "Status: PASS (no crash at depth ") (print depth) (print ")\n"))
+    (print "Status: FAIL (spine damaged)\n"))

--- a/benchmarks/ext-objects-small.scm
+++ b/benchmarks/ext-objects-small.scm
@@ -1,0 +1,41 @@
+;; Many live ext-objects (§7.5), scaled for small-heap configs.
+;; 20 mutexes is enough to make the finalize-list walk visible if
+;; it matters; small enough to fit comfortably.
+
+(print "=== Ext-objects finalize-walk (small) ===\n")
+
+(define mutex-count 20)
+(define gc-cycles 3000)
+(define throwaway-size 30)
+
+(define (make-mutexes n)
+  (let loop ((i n) (acc '()))
+    (if (= i 0) acc (loop (- i 1) (cons (make-mutex "m") acc)))))
+
+(define mutexes (make-mutexes mutex-count))
+(print "Live mutexes: ") (print mutex-count) (print "\n")
+
+(define (build-throwaway n)
+  (let loop ((i n) (acc '()))
+    (if (= i 0) acc (loop (- i 1) (cons i acc)))))
+
+(define (pressure k)
+  (if (= k 0) 'done
+      (begin
+        (build-throwaway throwaway-size)
+        (pressure (- k 1)))))
+
+(define t-start (time))
+(pressure gc-cycles)
+(define t-end (time))
+(define elapsed (- t-end t-start))
+
+(define live-len
+  (let loop ((l mutexes) (n 0))
+    (if (null? l) n (loop (cdr l) (+ n 1)))))
+(define ok (= live-len mutex-count))
+
+(print "  live after: ") (print live-len) (print "\n")
+(print "  elapsed:    ") (print elapsed) (print " ms\n")
+
+(if ok (print "Status: PASS\n") (print "Status: FAIL (mutex list damaged)\n"))

--- a/benchmarks/ext-objects.scm
+++ b/benchmarks/ext-objects.scm
@@ -1,0 +1,61 @@
+;; Many live ext-objects: finalize-list walk cost.
+;;
+;; Each (make-mutex) allocates a vm_ext_object_t and links it onto
+;; ext_object_list_head (vm-memory.c:631). On every GC,
+;; finalize_unmarked_ext_objects (vm-memory.c:447-467) walks the
+;; whole list before the heap sweep, regardless of how many entries
+;; are unmarked. This benchmark builds a long list of mutexes,
+;; keeps them all live, then runs allocation pressure -- every GC
+;; pays the O(mutex-count) finalize-list traversal.
+;;
+;; Compared against alloc-churn.scm (no ext-objects), the runtime
+;; delta isolates the ext-object finalize-walk cost per GC cycle.
+
+(print "=== Ext-objects finalize-walk ===\n")
+
+(define mutex-count 100)
+(define gc-cycles 5000)
+(define throwaway-size 200)
+
+(define (make-mutexes n acc)
+  (if (= n 0) acc
+      (make-mutexes (- n 1) (cons (make-mutex "m") acc))))
+
+(define mutexes (make-mutexes mutex-count '()))
+(print "Live mutexes: ") (print mutex-count) (print "\n")
+
+(define (build-throwaway n acc)
+  (if (= n 0) acc (build-throwaway (- n 1) (cons n acc))))
+
+(define (pressure k)
+  (if (= k 0) 'done
+      (begin
+        (build-throwaway throwaway-size '())
+        (pressure (- k 1)))))
+
+(print "Forcing GC pressure with ") (print gc-cycles)
+(print " throwaway lists of ") (print throwaway-size) (print " cells...\n")
+
+(define t-start (time))
+(pressure gc-cycles)
+(define t-end (time))
+(define elapsed (- t-end t-start))
+(define total-allocations (* gc-cycles throwaway-size))
+
+(define live-len
+  (let loop ((l mutexes) (n 0))
+    (if (null? l) n (loop (cdr l) (+ n 1)))))
+(define ok (= live-len mutex-count))
+
+(print "  live mutexes after pressure: ") (print live-len) (print "\n")
+(print "  elapsed:                     ") (print elapsed) (print " ms\n")
+(if (> elapsed 0)
+    (begin
+      (print "  rate:                        ")
+      (print (* (quotient total-allocations elapsed) 1000))
+      (print " allocs/sec\n"))
+    'skip)
+
+(if ok
+    (print "Status: PASS\n")
+    (print "Status: FAIL (mutex list damaged)\n"))

--- a/benchmarks/pool-near-full-small.scm
+++ b/benchmarks/pool-near-full-small.scm
@@ -1,0 +1,43 @@
+;; Pool-near-full sweep gate (§7.4), scaled for small-heap configs.
+;; live-cells=80 trips the 67% sweep gate on a 125-slot Zoul pool
+;; (80 / 125 = 64% — set just above the gate by raising to 84-90 in
+;; sensitivity runs; left at 80 here because at 84 the pool starts
+;; rejecting throwaway allocations).
+
+(print "=== Pool near full (small) ===\n")
+
+(define live-cells 40)
+(define gc-cycles 3000)
+(define throwaway-size 20)
+
+(define (build-list n)
+  (let loop ((i n) (acc '()))
+    (if (= i 0) acc (loop (- i 1) (cons i acc)))))
+
+(define live (build-list live-cells))
+(print "Live cells: ") (print live-cells) (print "\n")
+
+(define (build-throwaway n)
+  (let loop ((i n) (acc '()))
+    (if (= i 0) acc (loop (- i 1) (cons i acc)))))
+
+(define (pressure k)
+  (if (= k 0) 'done
+      (begin
+        (build-throwaway throwaway-size)
+        (pressure (- k 1)))))
+
+(define t-start (time))
+(pressure gc-cycles)
+(define t-end (time))
+(define elapsed (- t-end t-start))
+
+(define live-len
+  (let loop ((l live) (n 0))
+    (if (null? l) n (loop (cdr l) (+ n 1)))))
+(define ok (= live-len live-cells))
+
+(print "  live after: ") (print live-len) (print "\n")
+(print "  elapsed:    ") (print elapsed) (print " ms\n")
+
+(if ok (print "Status: PASS\n") (print "Status: FAIL\n"))

--- a/benchmarks/pool-near-full.scm
+++ b/benchmarks/pool-near-full.scm
@@ -1,0 +1,62 @@
+;; Object-pool near-full sweep cost.
+;;
+;; The pool sweep is gated to fire only when items >= 2 * capacity / 3
+;; (vm-mempool.c:290). Below that threshold the ref-bitmap is reset
+;; but no slot is reclaimed. This benchmark pre-allocates enough live
+;; cons cells to push the pool above the gate, then runs sustained
+;; allocation pressure. Every subsequent GC pays the full bitmap-scan
+;; sweep cost on top of the mark walk.
+;;
+;; Target relevance: most useful on Zoul (pool capacity = 3000 B /
+;; ~24 B = 125 slots, so ~85 live cells trips the gate). On POSIX the
+;; default pool is huge (~400k slots) and this benchmark will not trip
+;; the gate at the configured `live-cells` count -- adjust upward to
+;; reach 67% of the actual pool capacity if measuring there.
+
+(print "=== Pool near full ===\n")
+
+(define live-cells 100)
+(define gc-cycles 5000)
+(define throwaway-size 200)
+
+(define (build-list n acc)
+  (if (= n 0) acc (build-list (- n 1) (cons n acc))))
+
+(define live (build-list live-cells '()))
+(print "Live structure: ") (print live-cells) (print " cons cells\n")
+
+(define (build-throwaway n acc)
+  (if (= n 0) acc (build-throwaway (- n 1) (cons n acc))))
+
+(define (pressure k)
+  (if (= k 0) 'done
+      (begin
+        (build-throwaway throwaway-size '())
+        (pressure (- k 1)))))
+
+(print "Forcing GC pressure with ") (print gc-cycles)
+(print " throwaway lists of ") (print throwaway-size) (print " cells...\n")
+
+(define t-start (time))
+(pressure gc-cycles)
+(define t-end (time))
+(define elapsed (- t-end t-start))
+(define total-allocations (* gc-cycles throwaway-size))
+
+(define live-len
+  (let loop ((l live) (n 0))
+    (if (null? l) n (loop (cdr l) (+ n 1)))))
+(define ok (= live-len live-cells))
+
+(print "  live cells after pressure: ") (print live-len) (print "\n")
+(print "  elapsed:                   ") (print elapsed) (print " ms\n")
+(if (> elapsed 0)
+    (begin
+      (print "  rate:                      ")
+      (print (* (quotient total-allocations elapsed) 1000))
+      (print " allocs/sec\n"))
+    'skip)
+
+(if ok
+    (print "Status: PASS\n")
+    (print "Status: FAIL\n"))

--- a/benchmarks/shared-symtab-threads-small.scm
+++ b/benchmarks/shared-symtab-threads-small.scm
@@ -1,0 +1,48 @@
+;; Symbol-table × thread count (§7.2), small-tier.
+;; 8 small top-level bindings + 2 worker threads + main = 3 active.
+
+(print "=== Shared symtab × threads (small) ===\n")
+
+(define v1 (make-vector 4 1))
+(define v2 (make-vector 4 1))
+(define v3 (make-vector 4 1))
+(define v4 (make-vector 4 1))
+(define v5 (make-vector 4 1))
+(define v6 (make-vector 4 1))
+(define v7 (make-vector 4 1))
+(define v8 (make-vector 4 1))
+
+(define worker-count 2)
+(define iters-per-worker 1500)
+(define throwaway-size 25)
+
+(define (build-throwaway n)
+  (let loop ((i n) (acc '()))
+    (if (= i 0) acc (loop (- i 1) (cons i acc)))))
+
+(define (worker n)
+  (if (= n 0) 'done
+      (begin
+        (build-throwaway throwaway-size)
+        (worker (- n 1)))))
+
+(define (spawn n)
+  (if (= n 0) 'done
+      (begin
+        (thread-create! (lambda () (worker iters-per-worker)))
+        (spawn (- n 1)))))
+
+(spawn worker-count)
+(print worker-count) (print " worker(s) spawned\n")
+
+(define main-cycles 3000)
+(define t-start (time))
+(worker main-cycles)
+(define t-end (time))
+
+(print "  v1 still vector: ") (print (vector? v1)) (print "\n")
+(print "  elapsed:         ") (print (- t-end t-start)) (print " ms\n")
+
+(if (and (vector? v1) (vector? v8))
+    (print "Status: PASS\n")
+    (print "Status: FAIL\n"))

--- a/benchmarks/shared-symtab-threads.scm
+++ b/benchmarks/shared-symtab-threads.scm
@@ -1,0 +1,87 @@
+;; Symbol-table mark cost × thread count.
+;;
+;; mark_thread_references walks thread->program->symbols for every
+;; thread (vm-memory.c:263-265), with no memory_is_marked guard on
+;; the symbol-bindings loop. Threads sharing a program re-walk the
+;; same bindings every GC. This benchmark binds many top-level
+;; vectors, then spawns several allocator threads -- every GC pays
+;; (thread-count + 1) full symbol-table mark walks.
+;;
+;; For differential measurement, run twice: thread-count = 0 (just
+;; main) and thread-count = N. The runtime delta divided by GC count
+;; reveals the per-thread symbol-walk overhead. After the
+;; one-line memory_is_marked guard fix, the delta should collapse to
+;; near zero (each binding marked once across all threads).
+
+(print "=== Shared symbol-table × threads ===\n")
+
+;; Twenty top-level vectors. Each becomes a symbol_bindings entry
+;; that the marker re-enters once per thread on every GC.
+(define v01 (make-vector 30 1))
+(define v02 (make-vector 30 1))
+(define v03 (make-vector 30 1))
+(define v04 (make-vector 30 1))
+(define v05 (make-vector 30 1))
+(define v06 (make-vector 30 1))
+(define v07 (make-vector 30 1))
+(define v08 (make-vector 30 1))
+(define v09 (make-vector 30 1))
+(define v10 (make-vector 30 1))
+(define v11 (make-vector 30 1))
+(define v12 (make-vector 30 1))
+(define v13 (make-vector 30 1))
+(define v14 (make-vector 30 1))
+(define v15 (make-vector 30 1))
+(define v16 (make-vector 30 1))
+(define v17 (make-vector 30 1))
+(define v18 (make-vector 30 1))
+(define v19 (make-vector 30 1))
+(define v20 (make-vector 30 1))
+
+(define worker-count 4)
+(define iters-per-worker 5000)
+(define throwaway-size 100)
+
+(define (build-throwaway n acc)
+  (if (= n 0) acc (build-throwaway (- n 1) (cons n acc))))
+
+(define (worker n)
+  (if (= n 0) 'done
+      (begin
+        (build-throwaway throwaway-size '())
+        (worker (- n 1)))))
+
+(define (spawn n)
+  (if (= n 0) 'done
+      (begin
+        (thread-create! (lambda () (worker iters-per-worker)))
+        (spawn (- n 1)))))
+
+(print "Spawning ") (print worker-count) (print " worker threads...\n")
+(spawn worker-count)
+
+(define main-cycles 8000)
+(print "Main thread runs ") (print main-cycles)
+(print " allocation cycles alongside workers...\n")
+
+(define t-start (time))
+(worker main-cycles)
+(define t-end (time))
+(define elapsed (- t-end t-start))
+(define total-allocations
+  (* (+ main-cycles (* worker-count iters-per-worker)) throwaway-size))
+
+(print "  20 top-level bindings still vectors: ")
+(print (if (and (vector? v01) (vector? v20)) "yes" "NO")) (print "\n")
+(print "  elapsed (main):                      ")
+(print elapsed) (print " ms\n")
+(if (> elapsed 0)
+    (begin
+      (print "  rate (across all threads):           ")
+      (print (* (quotient total-allocations elapsed) 1000))
+      (print " allocs/sec\n"))
+    'skip)
+
+(if (and (vector? v01) (vector? v20))
+    (print "Status: PASS\n")
+    (print "Status: FAIL\n"))

--- a/benchmarks/wide-vector-small.scm
+++ b/benchmarks/wide-vector-small.scm
@@ -1,0 +1,46 @@
+;; Wide-fanout vector, scaled for small-heap configs (§7.3).
+;; Sized to fit a Zoul-tier pool (125 slots): 30-element vector with
+;; 2-cell sublists = ~90 cells live, comfortably below the gate.
+
+(print "=== Wide-fanout vector (small) ===\n")
+
+(define width 30)
+(define gc-cycles 3000)
+(define throwaway-size 30)
+
+(define wide (make-vector width '()))
+
+(define (fill-iter i)
+  (if (= i width)
+      'done
+      (begin
+        (vector-set! wide i (cons i (cons (* i 2) '())))
+        (fill-iter (+ i 1)))))
+
+(fill-iter 0)
+(print "Vector: ") (print width) (print " 2-cell entries\n")
+
+(define (build-throwaway n)
+  (let loop ((i n) (acc '()))
+    (if (= i 0) acc (loop (- i 1) (cons i acc)))))
+
+(define (pressure k)
+  (if (= k 0) 'done
+      (begin
+        (build-throwaway throwaway-size)
+        (pressure (- k 1)))))
+
+(define t-start (time))
+(pressure gc-cycles)
+(define t-end (time))
+(define elapsed (- t-end t-start))
+
+(define first-el (vector-ref wide 0))
+(define last-el (vector-ref wide (- width 1)))
+(define ok (and (= (car first-el) 0)
+                (= (car last-el) (- width 1))))
+
+(print "  intact:  ") (print (if ok "yes" "NO")) (print "\n")
+(print "  elapsed: ") (print elapsed) (print " ms\n")
+
+(if ok (print "Status: PASS\n") (print "Status: FAIL\n"))

--- a/benchmarks/wide-vector.scm
+++ b/benchmarks/wide-vector.scm
@@ -1,0 +1,67 @@
+;; Wide-fanout vector GC mark test.
+;;
+;; Builds one vector with N compound elements (a small 2-cell list
+;; each), kept live as a top-level binding, then runs sustained
+;; allocation pressure to force many GC cycles. Each cycle marks the
+;; vector header, the elements array, and recurses into every
+;; element. This isolates the VECTOR case of mark_object
+;; (vm-memory.c:199-211) and its per-element recursion.
+;;
+;; Companion to deep-structures.scm (depth) and memory-stress.scm
+;; (multiple roots). The expected scaling is linear in `width`: a
+;; doubling of width should roughly double per-GC mark time.
+
+(print "=== Wide-fanout vector ===\n")
+
+(define width 500)
+(define gc-cycles 5000)
+(define throwaway-size 200)
+
+(define wide (make-vector width '()))
+
+(define (fill-iter i)
+  (if (= i width)
+      'done
+      (begin
+        (vector-set! wide i (cons i (cons (* i 2) '())))
+        (fill-iter (+ i 1)))))
+
+(fill-iter 0)
+(print "Vector populated with ") (print width)
+(print " 2-cell entries\n")
+
+(define (build-throwaway n acc)
+  (if (= n 0) acc (build-throwaway (- n 1) (cons n acc))))
+
+(define (pressure k)
+  (if (= k 0) 'done
+      (begin
+        (build-throwaway throwaway-size '())
+        (pressure (- k 1)))))
+
+(print "Forcing GC pressure with ") (print gc-cycles)
+(print " throwaway lists of ") (print throwaway-size) (print " cells...\n")
+
+(define t-start (time))
+(pressure gc-cycles)
+(define t-end (time))
+(define elapsed (- t-end t-start))
+(define total-allocations (* gc-cycles throwaway-size))
+
+(define first-el (vector-ref wide 0))
+(define last-el (vector-ref wide (- width 1)))
+(define ok (and (= (car first-el) 0)
+                (= (car last-el) (- width 1))))
+
+(print "  vector intact: ") (print (if ok "yes" "NO")) (print "\n")
+(print "  elapsed:       ") (print elapsed) (print " ms\n")
+(if (> elapsed 0)
+    (begin
+      (print "  rate:          ")
+      (print (* (quotient total-allocations elapsed) 1000))
+      (print " allocs/sec\n"))
+    'skip)
+
+(if ok
+    (print "Status: PASS\n")
+    (print "Status: FAIL\n"))


### PR DESCRIPTION
Seven full-tier benchmarks plus six -small variants exercising different cost vectors for the mark-and-sweep GC:

  - alloc-and-drop: per-GC constant overhead with near-zero live set.
  - wide-vector: VECTOR mark walk over an N-element elements array.
  - pool-near-full: object-pool sweep gated at 2/3 fill.
  - ext-objects: linear walk of ext_object_list_head on every GC.
  - combined-deep-and-full: depth + multi-root + sweep gate together.
  - shared-symtab-threads: per-thread symbol-bindings re-mark cost.
  - crash-spine: recursive-marker C-stack overflow at large depth.

The -small variants are sized to fit Zoul-tier (5 / 3 kB) and mid-tier (32 / 16 kB) heap configurations. README.md gains a "GC stress suite" subsection summarising the cost vector each benchmark isolates.