### PR TITLE
scheme: fix inline-form argc bit collision

### DIFF
--- a/languages/scheme/bytecode.rkt
+++ b/languages/scheme/bytecode.rkt
@@ -320,21 +320,24 @@
 ;; Form Encoding
 ;; ============================================================================
 
-;; Inline form arg-count field is 6 bits.
-(define VM-MAX-INLINE-ARGC 63)
+;; Inline form arg-count field is 5 bits (bits 4-0). Bit 5 belongs
+;; to the form-type field -- a header with bit 5 set decodes as
+;; VM_FORM_LAMBDA and the call is treated as a reference to a
+;; nonexistent expression.
+(define VM-MAX-INLINE-ARGC 31)
 
 (define (encode-form-inline arg-count)
   ;; Inline form: single byte encoding
   ;; Bit 7: 1 (FORM token)
   ;; Bits 6-5: 00 (form-type=INLINE, extracted via >> 5 & 3)
-  ;; Bits 5-0: arg-count (6 bits, max 63)
+  ;; Bits 4-0: arg-count (5 bits, max 31)
   (when (> arg-count VM-MAX-INLINE-ARGC)
     (error 'encode-form-inline
            "too many arguments in form (~a exceeds VM inline limit of ~a)"
            arg-count VM-MAX-INLINE-ARGC))
   (let ([header (bitwise-ior #x80                     ; bit 7 = 1 (FORM token)
                              (arithmetic-shift 0 5)   ; bits 6-5 = 0 (INLINE)
-                             (bitwise-and arg-count #x3F))]) ; bits 5-0 = argc
+                             (bitwise-and arg-count #x1F))]) ; bits 4-0 = argc
     (expr-encoding 'form (bytes header))))
 
 ;; Lambda/ref form expr-id: 4 bits (simple) or 12 bits (extended, 4+8).

--- a/languages/scheme/tests/test-bytecode-format.rkt
+++ b/languages/scheme/tests/test-bytecode-format.rkt
@@ -138,9 +138,9 @@
 ;; Form type is bits 6-5, extracted as (header >> 5) & 3
 (define inline-type (bitwise-and (arithmetic-shift inline-header -5) #x03))
 (check-equal? inline-type 0 "Inline form type is 0")
-;; Arg count is the low 6 bits of the header (see VM_GET_ARGC). For
+;; Arg count is the low 5 bits of the header (see VM_GET_ARGC). For
 ;; (+ 1 2) the count is 3: operator + two args.
-(define inline-argc (bitwise-and inline-header #x3F))
+(define inline-argc (bitwise-and inline-header #x1F))
 (check-equal? inline-argc 3 "Inline form argc is operator + 2 args")
 (displayln (format "  Inline form header: 0x~x, argc: ~a"
                    inline-header inline-argc))


### PR DESCRIPTION
Same shape as the pyvelox encoder bug: VM-MAX-INLINE-ARGC was 63 and the mask was #x3F, but bit 5 is the low bit of the form-type field. Any (begin ...), (and ...), (or ...), or function call with >= 32 args silently emitted a header byte the VM decoded as VM_FORM_LAMBDA, redirecting to a nonexistent expression.

Tighten the cap to 31 and the mask to #x1F so encode-form-inline now refuses argc > 31 with a clear error. Update the matching test to read 5 bits.