### PR TITLE
vm-mempool: widen heap size multiply to size_t

### DIFF
--- a/core/vm-mempool.c
+++ b/core/vm-mempool.c
@@ -125,13 +125,13 @@ vm_mempool_create(vm_mempool_t *pool, uint16_t obj_size,
   memset(pool->alloc_bitmap, 0, bitmap_size);
   memset(pool->ref_bitmap, 0, bitmap_size);
 
-  pool->heap = VM_MEMPOOL_ALLOC(obj_size * capacity);
+  pool->heap = VM_MEMPOOL_ALLOC((size_t)obj_size * capacity);
   if(pool->heap == 0) {
     VM_MEMPOOL_FREE(pool->alloc_bitmap);
     VM_MEMPOOL_FREE(pool->ref_bitmap);
     VM_DEBUG(VM_DEBUG_MEDIUM,
              "Failed to create a mempool heap of size %lu\n",
-             (unsigned long)(obj_size * capacity));
+             (unsigned long)((size_t)obj_size * capacity));
     return 0;
   }
 


### PR DESCRIPTION
The obj_size (uint16_t) * capacity (uint32_t) product was evaluated in 32-bit and only then widened to the size_t that the allocator takes, so a product over 4 GB would wrap before the widening. Current callers derive capacity from fixed pool-size config (~10 MB max), so this is not triggerable today, but cast one operand to size_t to do the multiply in 64-bit as defensive hardening against future pool-size increases.