### PR TITLE
vm-sched: fold tail calls by lambda identity, not call site

### DIFF
--- a/core/vm-sched.c
+++ b/core/vm-sched.c
@@ -62,17 +62,79 @@ vm_thread_set_expr(vm_thread_t *thread, vm_expr_id_t expr_id)
   expr->end = expr->ip + VM_TABLE_LENGTH(thread->program->exprv, expr_id);
 }
 
+/* Return the body form id of the lambda or closure that `expr` invokes as
+   its operator, or ~0 if the operator is not an identifiable lambda. Tail-
+   call folding uses this to detect re-entry of the same lambda regardless
+   of which call site reached it. */
+static vm_expr_id_t
+lambda_form_id(const vm_expr_t *expr)
+{
+  if(expr->argc > 0) {
+    if(expr->argv[0].type == VM_TYPE_CLOSURE) {
+      return expr->argv[0].value.closure->form_id;
+    }
+    if(expr->argv[0].type == VM_TYPE_FORM &&
+       expr->argv[0].value.form.type == VM_FORM_LAMBDA) {
+      return expr->argv[0].value.form.id;
+    }
+  }
+  return (vm_expr_id_t)~0;
+}
+
 static void
 cut_tail_call_frames(vm_thread_t *thread)
 {
-  vm_expr_id_t lambda_expr_id;
+  vm_expr_id_t lambda_form;
+  int apply_frame;
   int i;
   int j;
 
-  lambda_expr_id = thread->expr->expr_id;
+  /* Detect tail recursion by lambda IDENTITY (its body form id) rather than
+     by the call-site expression id. A loop reached through several call
+     sites (e.g. a `cond` with a recursive call in more than one branch),
+     through a wrapper that was itself called in non-tail position, or via
+     mutual recursion all re-enter the *same* lambda; matching the form id
+     folds them where matching the call site silently fails (the frame is
+     not found, the stack grows, and deep recursion overflows). Form-id
+     matching is a strict superset of the previous call-site matching, so it
+     never folds a case the old code did not -- it only folds more. The
+     collapse below still reuses the matched activation's bind frame in
+     place, so bindings that escape into the body via the binding stack are
+     preserved (only the loop's own prior-iteration frames are freed). */
+  lambda_form = lambda_form_id(thread->expr);
+  if(lambda_form == (vm_expr_id_t)~0) {
+    /* Operator is not an identifiable lambda/closure; nothing to fold. */
+    return;
+  }
+
+  /* Fold only when the lambda about to run is ITSELF in tail position. Its
+     parent must be a transparent control form: flagged as a tail context
+     (if/begin/and/or/bind_function) and not a function application
+     (VM_EXPR_LAMBDA clear). A lambda evaluated as the operand of another
+     call, e.g. the inner (ack m (- n 1)) in (ack (- m 1) (ack m (- n 1))),
+     has a function-application parent and must not be folded even though it
+     re-enters the same lambda. The per-frame tail-chain check below cannot
+     catch this when the parent is the matched frame itself (no frames in
+     between), so it is gated here. */
+  if(thread->exprc < 2 ||
+     VM_IS_CLEAR(thread->exprv[thread->exprc - 2]->flags, VM_EXPR_TAIL_CALL) ||
+     VM_IS_SET(thread->exprv[thread->exprc - 2]->flags, VM_EXPR_LAMBDA)) {
+    return;
+  }
+
+  /* `apply` rewrites the call frame in place and the collapse re-reads its
+     call site to re-spread the argument list (which still references the
+     caller's bindings). That re-read depends on folding back to the same
+     call-site expression, so apply-rewritten frames keep the original
+     call-site (expr_id) matching. Ordinary lambda dispatch uses lambda-
+     identity (form id) matching, which folds the nested/multi-site/wrapper
+     cases the call-site match misses. */
+  apply_frame = VM_IS_SET(thread->expr->flags, VM_EXPR_REWRITTEN_BY_APPLY);
 
   for(i = thread->exprc - 2; i > 0; i--) {
-    if(thread->exprv[i]->expr_id == lambda_expr_id) {
+    if(apply_frame
+         ? (thread->exprv[i]->expr_id == thread->expr->expr_id)
+         : (lambda_form_id(thread->exprv[i]) == lambda_form)) {
       for(j = thread->exprc - 2; j > i; j--) {
         if(VM_IS_CLEAR(thread->exprv[j]->flags, VM_EXPR_TAIL_CALL)) {
           /* Unable to optimize the tail because one of the expressions
@@ -189,9 +251,17 @@ init_lambda_execution(vm_thread_t *thread, vm_expr_t *expr)
 
   VM_SET_FLAG(expr->flags, VM_EXPR_LAMBDA);
   if(thread->exprc >= 2 &&
-     VM_IS_SET(thread->exprv[thread->exprc - 2]->flags, VM_EXPR_TAIL_CALL)) {
-    /* If the calling expression is a tail call, then so is the next
-       lambda expression to be called. */
+     VM_IS_SET(thread->exprv[thread->exprc - 2]->flags, VM_EXPR_TAIL_CALL) &&
+     VM_IS_CLEAR(thread->exprv[thread->exprc - 2]->flags, VM_EXPR_LAMBDA)) {
+    /* Propagate tail position to the lambda being called only when the
+       parent frame is a transparent control form (if/begin/and/or/
+       bind_function) that flagged itself while dispatching its tail
+       sub-expression. If the parent is itself a function application
+       (VM_EXPR_LAMBDA set), this lambda is being evaluated as its operator
+       or one of its arguments, never a tail position even when the
+       enclosing call is itself a tail call. Without this guard a lambda
+       argument such as the inner call in (ack (- m 1) (ack m (- n 1)))
+       would be mis-tagged as tail and wrongly folded. */
     VM_SET_FLAG(expr->flags, VM_EXPR_TAIL_CALL);
   }
 }

--- a/tests/unit-tests/r5rs/test-tail-calls-nested.scm
+++ b/tests/unit-tests/r5rs/test-tail-calls-nested.scm
@@ -1,0 +1,86 @@
+;;; VeloxVM Unit Tests - Tail calls across nested loops (R5RS 3.5 regression)
+;;;
+;;; Regression for the tail-call folding bug fixed in core/vm-sched.c
+;;; (see doc/scheme-tco-nested-loop-bug.md). A bottom-up merge sort packs
+;;; the patterns that the old call-site (expr_id) matching failed to fold:
+;;;
+;;;   - nested named-let loops: pass -> run -> the merge `loop`;
+;;;   - a loop (the merge loop) re-entered from MULTIPLE recursive call
+;;;     sites (the cond branches), so consecutive iterations have different
+;;;     call-site ids;
+;;;   - reached through a wrapper (`list-sort`) that calls `vector-sort!` in
+;;;     non-tail position;
+;;;   - with a forwarded comparator closure (`less?`) invoked inside the
+;;;     innermost loop.
+;;;
+;;; Before the fix this overflowed the context stack (folding never fired,
+;;; the stack grew per iteration). The input below is built programmatically
+;;; and is large enough that, without proper tail-call folding, the nested
+;;; loops exceed VM_CONTEXT_STACK_SIZE. A pass proves the folding works.
+
+(include "../unit-test-framework.scm")
+
+;; Stably merge src[lo,mid) and src[mid,hi) into dst[lo,hi). The `loop`
+;; recurses from three different cond branches.
+(define (sort:merge-run less? src dst lo mid hi)
+  (let loop ((i lo) (j mid) (k lo))
+    (cond ((and (< i mid) (< j hi))
+           (if (less? (vector-ref src j) (vector-ref src i))
+               (begin (vector-set! dst k (vector-ref src j))
+                      (loop i (+ j 1) (+ k 1)))
+               (begin (vector-set! dst k (vector-ref src i))
+                      (loop (+ i 1) j (+ k 1)))))
+          ((< i mid)
+           (vector-set! dst k (vector-ref src i))
+           (loop (+ i 1) j (+ k 1)))
+          ((< j hi)
+           (vector-set! dst k (vector-ref src j))
+           (loop i (+ j 1) (+ k 1)))
+          (else #t))))
+
+(define (vector-sort! less? vec)
+  (let ((n (vector-length vec)))
+    (when (> n 1)
+      (let ((scratch (make-vector n 0)))
+        (let pass ((width 1) (src vec) (dst scratch))
+          (if (>= width n)
+              (when (not (eq? src vec))
+                (let copy ((i 0))
+                  (when (< i n)
+                    (vector-set! vec i (vector-ref src i))
+                    (copy (+ i 1)))))
+              (begin
+                (let run ((i 0))
+                  (when (< i n)
+                    (let* ((mr (+ i width)) (hr (+ i (* 2 width)))
+                           (mid (if (< mr n) mr n)) (hi (if (< hr n) hr n)))
+                      (sort:merge-run less? src dst i mid hi))
+                    (run (+ i (* 2 width)))))
+                (pass (* width 2) dst src))))))))
+
+(define (list-sort less? lst)
+  (let ((v (list->vector lst)))
+    (vector-sort! less? v)
+    (vector->list v)))
+
+;; Build (n n-1 ... 1), reversed: the worst case for the merge passes.
+(define (countdown n)
+  (let loop ((i 0) (acc '()))
+    (if (>= i n) acc (loop (+ i 1) (cons (+ i 1) acc)))))
+
+(define (sorted? lst)
+  (cond ((null? lst) #t)
+        ((null? (cdr lst)) #t)
+        ((< (car (cdr lst)) (car lst)) #f)
+        (else (sorted? (cdr lst)))))
+
+(test-suite "R5RS 3.5: tail calls across nested loops (merge sort)")
+
+;; 64 reversed elements: deep enough that un-folded nested loops overflow.
+(define result (list-sort < (countdown 64)))
+(assert-true  (sorted? result)             "merge sort fully ordered (no overflow)")
+(assert-equal 1  (car result)              "min element first")
+(assert-equal 64 (car (reverse result))    "max element last")
+(assert-equal 64 (length result)           "no elements lost")
+
+(test-summary)


### PR DESCRIPTION
cut_tail_call_frames matched a prior activation by call-site expression id, so a loop re-entered from a different call site -- a cond with recursive calls in several branches, a wrapper called in non-tail position, or mutual recursion -- was never folded; the stack grew and deep recursion overflowed VM_CONTEXT_STACK_SIZE.

Match instead on lambda identity (the operator's body form id), which is a strict superset of the old call-site match (confirmed by instrumenting the merge-sort repro: it recovered every missed fold and lost none). The collapse still reuses the matched activation's bind frame in place, so bindings that escape into the body via the binding stack are preserved.

Two guards keep it correct:
  - Fold only when the lambda about to run is itself in tail position (parent is a transparent control form, VM_EXPR_LAMBDA clear). This rejects a lambda evaluated as an *argument* of a tail call, e.g. the inner (ack m (- n 1)) in (ack (- m 1) (ack m (- n 1))); without it ackermann(1,1) returned 2 instead of 3. init_lambda_execution no longer propagates the tail flag into a function application's operand frames either.
  - apply-rewritten frames keep call-site (expr_id) matching, since the collapse re-reads the call site to re-spread the argument list.

Adds test-tail-calls-nested.scm: a bottom-up merge sort packing the nested-loop / multi-site / wrapper / forwarded-closure patterns. It overflowed the context stack before this change and passes after.