### PR TITLE
scheme: R7RS library system (define-library / import / export)

### DIFF
--- a/languages/scheme/library.rkt
+++ b/languages/scheme/library.rkt
@@ -3,22 +3,33 @@
 ;; VeloxVM Scheme Compiler - R7RS Library System
 ;; Copyright (c) 2026, RISE Research Institutes of Sweden AB
 ;;
-;; Structural lowering. `define-library` / `import` / `export` /
-;; `cond-expand` are lowered to ordinary top-level forms in the single flat
-;; namespace the rest of the pipeline already uses. See
-;; doc/r7rs-library-system-design.md.
+;; Lowers R7RS define-library / import / export / cond-expand to ordinary
+;; top-level forms in the single flat namespace the rest of the pipeline
+;; uses. A pure source-to-source pass: no VM-core or bytecode changes.
+;; See doc/r7rs-library-system-design.md.
 ;;
-;; Scope and deliberate limitations:
-;;   - Flat namespace, no isolation: two libraries that define the same
-;;     internal name collide, exactly as two hand-written top-level defines
-;;     would. Name-mangling for real isolation is layered on separately.
-;;   - Permissive: imports validate the library name but do not hide
-;;     un-imported names; every visible binding stays visible.
-;;   - Import sets: `only` / `except` are accepted and ignored (harmless
-;;     under permissive resolution); `prefix` / `rename` are rejected
-;;     (ignoring them would silently miscompile references).
-;;   - Macros exported by a library become globally visible (the expander
-;;     registers them globally); per-library macro hygiene is handled separately.
+;; Structural lowering (flatten libraries, resolve cond-expand,
+;; validate imports).
+;;
+;; Name isolation by mangling. Each library's top-level
+;; definitions are alpha-renamed to unique symbols (e.g. helper$L0), and
+;; references are rewritten per a per-library substitution map. This is
+;; sound without local-scope analysis: consistently renaming every
+;; occurrence of an identifier within a library's forms to a fresh,
+;; unique spelling is whole-identifier alpha-conversion, which preserves
+;; binding/shadowing structure (shadowing is positional). The only
+;; positions that must be left alone are quoted data. With the
+;; substitution-map model the import sets only / except / prefix / rename
+;; fall out naturally and are supported for user libraries.
+;;
+;; Deliberate limitations:
+;;   - Macros: a library's define-syntax forms are not mangled and its
+;;     macros remain globally visible. A library that mixes exported (or
+;;     internal) macros with mangled value bindings may misbehave;
+;;     per-library macro hygiene is handled separately.
+;;   - Import sets on *standard* libraries (only/except/prefix/rename)
+;;     need a per-standard-library export list we do not yet carry, so
+;;     they are rejected; plain (import (scheme base)) is a no-op.
 
 (require "reader.rkt")
 
@@ -34,9 +45,9 @@
 (define library-features
   '(veloxvm r5rs r7rs-subset exact-closed ratios))
 
-;; R7RS standard library names the compiler recognises. These
-;; are no-ops on import: their bindings already exist as VM primitives or
-;; as the auto-prepended runtime prelude.
+;; R7RS standard library names the compiler recognises. On import these
+;; are no-ops: their bindings already exist as VM primitives or as the
+;; auto-prepended runtime prelude, so nothing is mangled or substituted.
 (define standard-libraries
   (list '(scheme base) '(scheme write) '(scheme char) '(scheme inexact)
         '(scheme complex) '(scheme cxr) '(scheme file) '(scheme read)
@@ -47,7 +58,14 @@
 ;; A registered library
 ;; ---------------------------------------------------------------------------
 
-(struct lib (name exports imports body) #:transparent)
+;; index    : unique integer, used to build mangled names
+;; exports  : list of export specs (symbol | (rename internal external))
+;; imports  : list of import sets
+;; body     : flattened top-level forms (post cond-expand + include)
+;; own      : list of names this library defines at top level (to mangle)
+;; mangle   : hash own-name -> mangled symbol
+;; exp-map  : list of (public-name . mangled-symbol) for exported names
+(struct lib (name index exports imports body own mangle exp-map) #:mutable #:transparent)
 
 ;; Library names are lists of symbols and/or exact integers, e.g.
 ;; (scheme base) or (srfi 1). Used directly as equal?-based hash keys.
@@ -56,13 +74,13 @@
        (pair? x)
        (andmap (lambda (e) (or (symbol? e) (exact-integer? e))) x)))
 
+(define (standard-library? name) (and (member name standard-libraries) #t))
+
 ;; ---------------------------------------------------------------------------
 ;; Form predicates
 ;; ---------------------------------------------------------------------------
 
-(define (tagged? form sym)
-  (and (pair? form) (eq? (car form) sym)))
-
+(define (tagged? form sym) (and (pair? form) (eq? (car form) sym)))
 (define (define-library-form? f) (tagged? f 'define-library))
 (define (cond-expand-form? f)    (tagged? f 'cond-expand))
 (define (import-form? f)         (tagged? f 'import))
@@ -100,36 +118,98 @@
       [(feature-present? (caar cs) known-libs) (cdar cs)]
       [else (loop (cdr cs))])))
 
-;; ---------------------------------------------------------------------------
-;; Import-set parsing
-;; ---------------------------------------------------------------------------
-
-;; Reduce an import set to the underlying library name. `only`/`except`
-;; wrap a set and are accepted (their filtering is a no-op under permissive
-;; resolution). `prefix`/`rename` change the spelling the program uses, so
-;; ignoring them would miscompile -- rejected.
-(define (import-set->name iset)
-  (cond
-    [(and (pair? iset) (memq (car iset) '(only except)))
-     (import-set->name (cadr iset))]
-    [(and (pair? iset) (memq (car iset) '(prefix rename)))
-     (error 'import
-            "import set '~a' is not supported: ~a"
-            (car iset) iset)]
-    [(library-name? iset) iset]
-    [else (error 'import "malformed import set: ~a" iset)]))
-
 (define (library-known? name known-libs)
-  (or (and (member name standard-libraries) #t)
-      (and (member name known-libs) #t)))
+  (or (standard-library? name) (and (member name known-libs) #t)))
+
+;; ---------------------------------------------------------------------------
+;; Collecting a body's top-level definition names
+;; ---------------------------------------------------------------------------
+
+;; The name a (define ...) target introduces, peeling curried defines.
+(define (define-target-name target)
+  (cond [(symbol? target) target]
+        [(pair? target) (define-target-name (car target))]
+        [else #f]))
+
+;; Names in a formals list (proper, improper, or a bare rest symbol).
+(define (formals->names formals)
+  (cond [(symbol? formals) (list formals)]
+        [(pair? formals) (cons (car formals) (formals->names (cdr formals)))]
+        [else '()]))
+
+;; The top-level names introduced by a define-record-type form:
+;; the type name, constructor, predicate, and each accessor/mutator.
+(define (record-type-names f)
+  ;; (define-record-type NAME (CTOR field ...) PRED (field ACC [MUT]) ...)
+  (define names '())
+  (define (add! x) (when (symbol? x) (set! names (cons x names))))
+  (when (>= (length f) 4)
+    (add! (define-target-name (list-ref f 1)))       ; type name
+    (let ([ctor (list-ref f 2)])                      ; constructor
+      (when (pair? ctor) (add! (car ctor))))
+    (add! (list-ref f 3))                             ; predicate
+    (for ([spec (drop f 4)])                          ; field specs
+      (when (pair? spec)
+        (when (>= (length spec) 2) (add! (list-ref spec 1)))  ; accessor
+        (when (>= (length spec) 3) (add! (list-ref spec 2)))))) ; mutator
+  (reverse names))
+
+(define (defined-names-of f)
+  (cond
+    [(not (pair? f)) '()]
+    [(eq? (car f) 'define)
+     (let ([n (define-target-name (and (pair? (cdr f)) (cadr f)))])
+       (if n (list n) '()))]
+    [(eq? (car f) 'define-values)
+     (if (pair? (cdr f)) (formals->names (cadr f)) '())]
+    [(eq? (car f) 'define-record-type) (record-type-names f)]
+    [(eq? (car f) 'begin) (append-map defined-names-of (cdr f))]
+    ;; define-syntax: a macro keyword, not a value binding -- not mangled.
+    [else '()]))
+
+(define (collect-defined-names forms) (append-map defined-names-of forms))
+
+;; ---------------------------------------------------------------------------
+;; Substitution (alpha-renaming) walk
+;; ---------------------------------------------------------------------------
+
+(define (symbol-append a b)
+  (string->symbol (string-append (symbol->string a) (symbol->string b))))
+
+;; Rewrite every symbol occurrence found in `subst`, except inside quoted
+;; data. define-syntax / let-syntax / letrec-syntax forms are left
+;; untouched (macros are not mangled here).
+(define (subst-walk form subst)
+  (cond
+    [(symbol? form) (hash-ref subst form form)]
+    [(not (pair? form)) form]
+    [(memq (car form) '(quote define-syntax let-syntax letrec-syntax)) form]
+    [(eq? (car form) 'quasiquote) (list 'quasiquote (qq-walk (cadr form) subst 1))]
+    [else (cons (subst-walk (car form) subst)
+                (subst-walk (cdr form) subst))]))
+
+;; Quasiquote-aware walk: substitute only inside unquote / unquote-splicing
+;; at the matching nesting level; leave literal template data alone.
+(define (qq-walk form subst level)
+  (cond
+    [(not (pair? form)) form]
+    [(eq? (car form) 'unquote)
+     (if (= level 1)
+         (list 'unquote (subst-walk (cadr form) subst))
+         (list 'unquote (qq-walk (cadr form) subst (sub1 level))))]
+    [(eq? (car form) 'unquote-splicing)
+     (if (= level 1)
+         (list 'unquote-splicing (subst-walk (cadr form) subst))
+         (list 'unquote-splicing (qq-walk (cadr form) subst (sub1 level))))]
+    [(eq? (car form) 'quasiquote)
+     (list 'quasiquote (qq-walk (cadr form) subst (add1 level)))]
+    [else (cons (qq-walk (car form) subst level)
+                (qq-walk (cdr form) subst level))]))
 
 ;; ---------------------------------------------------------------------------
 ;; Library registration
 ;; ---------------------------------------------------------------------------
 
-;; Process a list of library declarations, accumulating into mutable boxes.
-;; Declarations: export, import, begin, include, include-ci,
-;; include-library-declarations, cond-expand.
 (define (process-declarations decls source-file known-libs
                               exports-box imports-box body-box)
   (define (add-exports! specs) (set-box! exports-box (append (unbox exports-box) specs)))
@@ -141,13 +221,11 @@
       [(tagged? d 'import) (add-imports! (cdr d))]
       [(tagged? d 'begin)  (add-body! (cdr d))]
       [(include-form? d)
-       ;; (include "f" ...) / (include-ci "f" ...): splice each file's
-       ;; expressions into the body. include-ci is treated as include
-       ;; (no case folding -- a documented limitation).
+       ;; (include "f" ...) / (include-ci "f" ...). include-ci is
+       ;; treated as include (no case folding -- a documented limitation).
        (for ([path (cdr d)])
          (add-body! (read-included-exprs path source-file)))]
       [(tagged? d 'include-library-declarations)
-       ;; Splice declarations (not expressions) from each file, recursively.
        (for ([path (cdr d)])
          (process-declarations (read-included-exprs path source-file)
                                source-file known-libs
@@ -158,7 +236,7 @@
                              exports-box imports-box body-box)]
       [else (error 'define-library "unknown library declaration: ~a" d)])))
 
-(define (register-library! form registry source-file known-libs)
+(define (register-library! form registry source-file known-libs index)
   (define name (cadr form))
   (unless (library-name? name)
     (error 'define-library "invalid library name: ~a" name))
@@ -167,18 +245,94 @@
   (define body-box (box '()))
   (process-declarations (cddr form) source-file known-libs
                         exports-box imports-box body-box)
+  (define body (unbox body-box))
+  (define own (remove-duplicates (collect-defined-names body)))
+  ;; Mangle map: own-name -> own-name$L<index>.
+  (define mangle (make-hash))
+  (define suffix (string->symbol (format "$L~a" index)))
+  (for ([n own]) (hash-set! mangle n (symbol-append n suffix)))
+  ;; Export map: public-name -> mangled. Supports (rename internal external).
+  (define exp-map
+    (for/list ([spec (unbox exports-box)])
+      (define-values (internal external)
+        (cond
+          [(symbol? spec) (values spec spec)]
+          [(and (tagged? spec 'rename) (= (length spec) 3)) (values (cadr spec) (caddr spec))]
+          [else (error 'export "malformed export spec: ~a" spec)]))
+      (unless (hash-has-key? mangle internal)
+        (error 'export "library ~a exports undefined name: ~a" name internal))
+      (cons external (hash-ref mangle internal))))
   (hash-set! registry name
-             (lib name (unbox exports-box) (unbox imports-box) (unbox body-box))))
+             (lib name index (unbox exports-box) (unbox imports-box)
+                  body own mangle exp-map)))
+
+;; ---------------------------------------------------------------------------
+;; Import-set resolution -> substitution entries (public-name . target)
+;; ---------------------------------------------------------------------------
+
+;; Underlying library name of an import set (peeling only/except/prefix/rename).
+(define (import-base iset)
+  (if (and (pair? iset) (memq (car iset) '(only except prefix rename)))
+      (import-base (cadr iset))
+      iset))
+
+;; Resolve an import set to a list of (public-name . target-symbol) pairs.
+;; Standard libraries contribute no entries (their names resolve directly);
+;; an import-set operator on a standard library is rejected.
+(define (resolve-import-set iset registry)
+  (define base (import-base iset))
+  (define is-standard (standard-library? base))
+  (cond
+    [(library-name? iset)
+     (cond
+       [is-standard '()]
+       [(hash-ref registry iset #f) => lib-exp-map]
+       [else (error 'import "unknown library: ~a" iset)])]
+    [(and (pair? iset) is-standard)
+     (error 'import
+            "import set '~a' on standard library ~a needs an export list: ~a"
+            (car iset) base iset)]
+    [(tagged? iset 'only)
+     (let ([inner (resolve-import-set (cadr iset) registry)]
+           [ids (cddr iset)])
+       (for ([id ids])
+         (unless (assq id inner)
+           (error 'import "(only ...) names ~a not exported by ~a" id base)))
+       (filter (lambda (p) (memq (car p) ids)) inner))]
+    [(tagged? iset 'except)
+     (let ([inner (resolve-import-set (cadr iset) registry)]
+           [ids (cddr iset)])
+       (filter (lambda (p) (not (memq (car p) ids))) inner))]
+    [(tagged? iset 'prefix)
+     (let ([inner (resolve-import-set (cadr iset) registry)]
+           [p (caddr iset)])
+       (map (lambda (pr) (cons (symbol-append p (car pr)) (cdr pr))) inner))]
+    [(tagged? iset 'rename)
+     (let* ([inner (resolve-import-set (cadr iset) registry)]
+            [renames (cddr iset)])  ; each (from to)
+       (map (lambda (pr)
+              (let ([r (assq (car pr) (map (lambda (x) (cons (car x) (cadr x))) renames))])
+                (if r (cons (cdr r) (cdr pr)) pr)))
+            inner))]
+    [else (error 'import "malformed import set: ~a" iset)]))
+
+;; Merge import entries into a substitution hash, flagging conflicts where
+;; one name would resolve to two different bindings.
+(define (merge-import-entries! subst entries context)
+  (for ([pr entries])
+    (define name (car pr))
+    (define target (cdr pr))
+    (cond
+      [(and (hash-has-key? subst name) (not (eq? (hash-ref subst name) target)))
+       (error 'import "~a: ~a imported with conflicting bindings" context name)]
+      [else (hash-set! subst name target)])))
 
 ;; ---------------------------------------------------------------------------
 ;; Dependency ordering
 ;; ---------------------------------------------------------------------------
 
-;; Emit libraries so each is defined before any (registered) library that
-;; imports it. Standard-library imports are ignored as edges. Cyclic user
-;; imports are an error.
 (define (topo-sort-libraries registry order)
-  (define visited (make-hash))   ; name -> 'done
+  (define visited (make-hash))
   (define in-progress (make-hash))
   (define result '())
   (define (visit name)
@@ -188,11 +342,9 @@
        (error 'define-library "circular library import involving ~a" name)]
       [else
        (hash-set! in-progress name #t)
-       (define l (hash-ref registry name))
-       (for ([iset (lib-imports l)])
-         (define dep (import-set->name iset))
-         (when (hash-has-key? registry dep)
-           (visit dep)))
+       (for ([iset (lib-imports (hash-ref registry name))])
+         (define dep (import-base iset))
+         (when (hash-has-key? registry dep) (visit dep)))
        (hash-remove! in-progress name)
        (hash-set! visited name 'done)
        (set! result (cons name result))]))
@@ -203,9 +355,6 @@
 ;; Top-level lowering
 ;; ---------------------------------------------------------------------------
 
-;; Lower all library/import/cond-expand forms in a top-level expression
-;; list to a flat list of ordinary forms. `source-file` is used to resolve
-;; includes inside libraries and cond-expand clauses.
 (define (lower-libraries exprs [source-file #f])
   ;; Shallow pre-scan of library names so (library X) cond-expand tests and
   ;; import validation are independent of source order.
@@ -213,38 +362,63 @@
     (for/list ([f exprs] #:when (define-library-form? f)) (cadr f)))
 
   (define registry (make-hash))
-  (define lib-order '())     ; registered names, definition order (reversed)
-  (define program-forms '()) ; non-library top-level forms (reversed)
+  (define lib-order '())       ; registered names, definition order (reversed)
+  (define program-forms '())   ; non-library top-level forms (reversed)
+  (define program-imports '()) ; top-level import sets (reversed)
+  (define next-index 0)
 
   (define (handle f)
     (cond
       [(include-form? f)
-       ;; Top-level includes are normally expanded by the reader already;
-       ;; this covers includes revealed by selecting a cond-expand clause.
+       ;; Covers includes revealed by selecting a cond-expand clause;
+       ;; ordinary top-level includes are expanded by the reader already.
        (for ([path (cdr f)])
          (for-each handle (read-included-exprs path source-file)))]
       [(cond-expand-form? f)
        (for-each handle (select-cond-expand-clause (cdr f) known-libs))]
       [(define-library-form? f)
-       (register-library! f registry source-file known-libs)
+       (register-library! f registry source-file known-libs next-index)
+       (set! next-index (add1 next-index))
        (set! lib-order (cons (cadr f) lib-order))]
       [(import-form? f)
-       ;; Top-level program import: validate names, then drop.
-       (for ([iset (cdr f)])
-         (define name (import-set->name iset))
-         (unless (library-known? name known-libs)
-           (error 'import "unknown library: ~a" name)))]
+       (set! program-imports (append (reverse (cdr f)) program-imports))]
       [else (set! program-forms (cons f program-forms))]))
 
   (for-each handle exprs)
+  (set! program-imports (reverse program-imports))
+  (set! program-forms (reverse program-forms))
 
-  ;; Validate each library's own imports too (catches typos in deps).
+  ;; Validate each library's own imports (catches typos in deps).
   (for ([(name l) (in-hash registry)])
     (for ([iset (lib-imports l)])
-      (define dep (import-set->name iset))
+      (define dep (import-base iset))
       (unless (library-known? dep known-libs)
         (error 'import "library ~a imports unknown library: ~a" name dep))))
 
+  ;; Build each library's substitution: imports first, own names override.
+  (define (library-subst l)
+    (define subst (make-hash))
+    (for ([iset (lib-imports l)])
+      (merge-import-entries! subst (resolve-import-set iset registry) (lib-name l)))
+    (for ([(name mangled) (in-hash (lib-mangle l))]) (hash-set! subst name mangled))
+    subst)
+
+  ;; Build the program's substitution from top-level imports, then drop any
+  ;; name the program defines itself (a program-level define shadows it).
+  (define program-subst (make-hash))
+  (for ([iset program-imports])
+    (merge-import-entries! program-subst (resolve-import-set iset registry) "program"))
+  (for ([n (collect-defined-names program-forms)])
+    (hash-remove! program-subst n))
+
+  ;; Emit mangled library bodies (dependency order) then mangled program.
   (define ordered (topo-sort-libraries registry (reverse lib-order)))
-  (append (append-map (lambda (name) (lib-body (hash-ref registry name))) ordered)
-          (reverse program-forms)))
+  (define lib-out
+    (append-map (lambda (name)
+                  (define l (hash-ref registry name))
+                  (define s (library-subst l))
+                  (map (lambda (form) (subst-walk form s)) (lib-body l)))
+                ordered))
+  (define prog-out
+    (map (lambda (form) (subst-walk form program-subst)) program-forms))
+  (append lib-out prog-out))

--- a/languages/scheme/library.rkt
+++ b/languages/scheme/library.rkt
@@ -22,11 +22,21 @@
 ;; substitution-map model the import sets only / except / prefix / rename
 ;; fall out naturally and are supported for user libraries.
 ;;
+;; Macros participate in mangling. A library's define-syntax
+;; names are treated as top-level definitions and mangled like values, and
+;; the substitution walk no longer skips macro forms, so a macro template's
+;; references to its library's own (possibly non-exported) bindings are
+;; rewritten consistently. Because the expander is global and keyed by
+;; name, mangling macro names to unique symbols yields per-library macro
+;; isolation for free (a non-importer never names m$L<index>) and lets
+;; export / import sets (only/except/prefix/rename) apply to macros exactly
+;; as they do to values -- with no expander changes.
+;;
 ;; Deliberate limitations:
-;;   - Macros: a library's define-syntax forms are not mangled and its
-;;     macros remain globally visible. A library that mixes exported (or
-;;     internal) macros with mangled value bindings may misbehave;
-;;     per-library macro hygiene is handled separately.
+;;   - Macro hygiene edges: syntax-rules literal identifiers are matched by
+;;     spelling, so a library binding (or import) whose name coincides with
+;;     a macro literal can interact badly. This is the existing expander's
+;;     hygiene gap, not introduced here.
 ;;   - Import sets on *standard* libraries (only/except/prefix/rename)
 ;;     need a per-standard-library export list we do not yet carry, so
 ;;     they are rejected; plain (import (scheme base)) is a no-op.
@@ -164,7 +174,10 @@
      (if (pair? (cdr f)) (formals->names (cadr f)) '())]
     [(eq? (car f) 'define-record-type) (record-type-names f)]
     [(eq? (car f) 'begin) (append-map defined-names-of (cdr f))]
-    ;; define-syntax: a macro keyword, not a value binding -- not mangled.
+    ;; define-syntax: the macro keyword is a top-level definition; mangling
+    ;; it isolates the macro per library and lets export/import sets apply.
+    [(eq? (car f) 'define-syntax)
+     (if (and (pair? (cdr f)) (symbol? (cadr f))) (list (cadr f)) '())]
     [else '()]))
 
 (define (collect-defined-names forms) (append-map defined-names-of forms))
@@ -177,13 +190,17 @@
   (string->symbol (string-append (symbol->string a) (symbol->string b))))
 
 ;; Rewrite every symbol occurrence found in `subst`, except inside quoted
-;; data. define-syntax / let-syntax / letrec-syntax forms are left
-;; untouched (macros are not mangled here).
+;; data. Macro forms (define-syntax / let-syntax / letrec-syntax) ARE
+;; walked: a template's free references to library bindings, and macro
+;; keywords that are library names, get rewritten. syntax-rules pattern
+;; variables, literals, and the ellipsis are left alone because they do not
+;; appear in `subst` (a library name colliding with a literal is the known
+;; expander hygiene edge, not handled here).
 (define (subst-walk form subst)
   (cond
     [(symbol? form) (hash-ref subst form form)]
     [(not (pair? form)) form]
-    [(memq (car form) '(quote define-syntax let-syntax letrec-syntax)) form]
+    [(eq? (car form) 'quote) form]
     [(eq? (car form) 'quasiquote) (list 'quasiquote (qq-walk (cadr form) subst 1))]
     [else (cons (subst-walk (car form) subst)
                 (subst-walk (cdr form) subst))]))

--- a/languages/scheme/library.rkt
+++ b/languages/scheme/library.rkt
@@ -1,0 +1,250 @@
+#lang racket
+
+;; VeloxVM Scheme Compiler - R7RS Library System
+;; Copyright (c) 2026, RISE Research Institutes of Sweden AB
+;;
+;; Structural lowering. `define-library` / `import` / `export` /
+;; `cond-expand` are lowered to ordinary top-level forms in the single flat
+;; namespace the rest of the pipeline already uses. See
+;; doc/r7rs-library-system-design.md.
+;;
+;; Scope and deliberate limitations:
+;;   - Flat namespace, no isolation: two libraries that define the same
+;;     internal name collide, exactly as two hand-written top-level defines
+;;     would. Name-mangling for real isolation is layered on separately.
+;;   - Permissive: imports validate the library name but do not hide
+;;     un-imported names; every visible binding stays visible.
+;;   - Import sets: `only` / `except` are accepted and ignored (harmless
+;;     under permissive resolution); `prefix` / `rename` are rejected
+;;     (ignoring them would silently miscompile references).
+;;   - Macros exported by a library become globally visible (the expander
+;;     registers them globally); per-library macro hygiene is handled separately.
+
+(require "reader.rkt")
+
+(provide lower-libraries)
+
+;; ---------------------------------------------------------------------------
+;; Feature set and known standard libraries
+;; ---------------------------------------------------------------------------
+
+;; cond-expand feature identifiers. MUST stay in sync with the (features)
+;; procedure in runtime/r7rs-features.scm -- the compile-time selector here
+;; and the runtime list there are two views of the same capability set.
+(define library-features
+  '(veloxvm r5rs r7rs-subset exact-closed ratios))
+
+;; R7RS standard library names the compiler recognises. These
+;; are no-ops on import: their bindings already exist as VM primitives or
+;; as the auto-prepended runtime prelude.
+(define standard-libraries
+  (list '(scheme base) '(scheme write) '(scheme char) '(scheme inexact)
+        '(scheme complex) '(scheme cxr) '(scheme file) '(scheme read)
+        '(scheme time) '(scheme process-context) '(scheme lazy)
+        '(scheme load) '(scheme repl) '(scheme eval) '(scheme r5rs)))
+
+;; ---------------------------------------------------------------------------
+;; A registered library
+;; ---------------------------------------------------------------------------
+
+(struct lib (name exports imports body) #:transparent)
+
+;; Library names are lists of symbols and/or exact integers, e.g.
+;; (scheme base) or (srfi 1). Used directly as equal?-based hash keys.
+(define (library-name? x)
+  (and (list? x)
+       (pair? x)
+       (andmap (lambda (e) (or (symbol? e) (exact-integer? e))) x)))
+
+;; ---------------------------------------------------------------------------
+;; Form predicates
+;; ---------------------------------------------------------------------------
+
+(define (tagged? form sym)
+  (and (pair? form) (eq? (car form) sym)))
+
+(define (define-library-form? f) (tagged? f 'define-library))
+(define (cond-expand-form? f)    (tagged? f 'cond-expand))
+(define (import-form? f)         (tagged? f 'import))
+(define (include-form? f)
+  (and (pair? f) (memq (car f) '(include include-ci)) #t))
+
+;; ---------------------------------------------------------------------------
+;; cond-expand
+;; ---------------------------------------------------------------------------
+
+;; A feature requirement is: a feature id (symbol); (library <name>);
+;; (and req ...); (or req ...); (not req). `else` is handled at clause
+;; level, not here.
+(define (feature-present? req known-libs)
+  (cond
+    [(symbol? req) (and (memq req library-features) #t)]
+    [(pair? req)
+     (case (car req)
+       [(library) (library-known? (cadr req) known-libs)]
+       [(and) (andmap (lambda (r) (feature-present? r known-libs)) (cdr req))]
+       [(or)  (ormap  (lambda (r) (feature-present? r known-libs)) (cdr req))]
+       [(not) (not (feature-present? (cadr req) known-libs))]
+       [else (error 'cond-expand "unknown feature requirement: ~a" req)])]
+    [else (error 'cond-expand "malformed feature requirement: ~a" req)]))
+
+;; Select the body (list of forms/declarations) of the first matching
+;; clause, or '() if none match and there is no else clause.
+(define (select-cond-expand-clause clauses known-libs)
+  (let loop ([cs clauses])
+    (cond
+      [(null? cs) '()]
+      [(not (and (pair? (car cs)) (pair? (cdar cs))))
+       (error 'cond-expand "malformed clause: ~a" (car cs))]
+      [(eq? (caar cs) 'else) (cdar cs)]
+      [(feature-present? (caar cs) known-libs) (cdar cs)]
+      [else (loop (cdr cs))])))
+
+;; ---------------------------------------------------------------------------
+;; Import-set parsing
+;; ---------------------------------------------------------------------------
+
+;; Reduce an import set to the underlying library name. `only`/`except`
+;; wrap a set and are accepted (their filtering is a no-op under permissive
+;; resolution). `prefix`/`rename` change the spelling the program uses, so
+;; ignoring them would miscompile -- rejected.
+(define (import-set->name iset)
+  (cond
+    [(and (pair? iset) (memq (car iset) '(only except)))
+     (import-set->name (cadr iset))]
+    [(and (pair? iset) (memq (car iset) '(prefix rename)))
+     (error 'import
+            "import set '~a' is not supported: ~a"
+            (car iset) iset)]
+    [(library-name? iset) iset]
+    [else (error 'import "malformed import set: ~a" iset)]))
+
+(define (library-known? name known-libs)
+  (or (and (member name standard-libraries) #t)
+      (and (member name known-libs) #t)))
+
+;; ---------------------------------------------------------------------------
+;; Library registration
+;; ---------------------------------------------------------------------------
+
+;; Process a list of library declarations, accumulating into mutable boxes.
+;; Declarations: export, import, begin, include, include-ci,
+;; include-library-declarations, cond-expand.
+(define (process-declarations decls source-file known-libs
+                              exports-box imports-box body-box)
+  (define (add-exports! specs) (set-box! exports-box (append (unbox exports-box) specs)))
+  (define (add-imports! sets)  (set-box! imports-box (append (unbox imports-box) sets)))
+  (define (add-body! forms)    (set-box! body-box   (append (unbox body-box) forms)))
+  (for ([d decls])
+    (cond
+      [(tagged? d 'export) (add-exports! (cdr d))]
+      [(tagged? d 'import) (add-imports! (cdr d))]
+      [(tagged? d 'begin)  (add-body! (cdr d))]
+      [(include-form? d)
+       ;; (include "f" ...) / (include-ci "f" ...): splice each file's
+       ;; expressions into the body. include-ci is treated as include
+       ;; (no case folding -- a documented limitation).
+       (for ([path (cdr d)])
+         (add-body! (read-included-exprs path source-file)))]
+      [(tagged? d 'include-library-declarations)
+       ;; Splice declarations (not expressions) from each file, recursively.
+       (for ([path (cdr d)])
+         (process-declarations (read-included-exprs path source-file)
+                               source-file known-libs
+                               exports-box imports-box body-box))]
+      [(cond-expand-form? d)
+       (process-declarations (select-cond-expand-clause (cdr d) known-libs)
+                             source-file known-libs
+                             exports-box imports-box body-box)]
+      [else (error 'define-library "unknown library declaration: ~a" d)])))
+
+(define (register-library! form registry source-file known-libs)
+  (define name (cadr form))
+  (unless (library-name? name)
+    (error 'define-library "invalid library name: ~a" name))
+  (define exports-box (box '()))
+  (define imports-box (box '()))
+  (define body-box (box '()))
+  (process-declarations (cddr form) source-file known-libs
+                        exports-box imports-box body-box)
+  (hash-set! registry name
+             (lib name (unbox exports-box) (unbox imports-box) (unbox body-box))))
+
+;; ---------------------------------------------------------------------------
+;; Dependency ordering
+;; ---------------------------------------------------------------------------
+
+;; Emit libraries so each is defined before any (registered) library that
+;; imports it. Standard-library imports are ignored as edges. Cyclic user
+;; imports are an error.
+(define (topo-sort-libraries registry order)
+  (define visited (make-hash))   ; name -> 'done
+  (define in-progress (make-hash))
+  (define result '())
+  (define (visit name)
+    (cond
+      [(hash-has-key? visited name) (void)]
+      [(hash-has-key? in-progress name)
+       (error 'define-library "circular library import involving ~a" name)]
+      [else
+       (hash-set! in-progress name #t)
+       (define l (hash-ref registry name))
+       (for ([iset (lib-imports l)])
+         (define dep (import-set->name iset))
+         (when (hash-has-key? registry dep)
+           (visit dep)))
+       (hash-remove! in-progress name)
+       (hash-set! visited name 'done)
+       (set! result (cons name result))]))
+  (for ([name order]) (visit name))
+  (reverse result))
+
+;; ---------------------------------------------------------------------------
+;; Top-level lowering
+;; ---------------------------------------------------------------------------
+
+;; Lower all library/import/cond-expand forms in a top-level expression
+;; list to a flat list of ordinary forms. `source-file` is used to resolve
+;; includes inside libraries and cond-expand clauses.
+(define (lower-libraries exprs [source-file #f])
+  ;; Shallow pre-scan of library names so (library X) cond-expand tests and
+  ;; import validation are independent of source order.
+  (define known-libs
+    (for/list ([f exprs] #:when (define-library-form? f)) (cadr f)))
+
+  (define registry (make-hash))
+  (define lib-order '())     ; registered names, definition order (reversed)
+  (define program-forms '()) ; non-library top-level forms (reversed)
+
+  (define (handle f)
+    (cond
+      [(include-form? f)
+       ;; Top-level includes are normally expanded by the reader already;
+       ;; this covers includes revealed by selecting a cond-expand clause.
+       (for ([path (cdr f)])
+         (for-each handle (read-included-exprs path source-file)))]
+      [(cond-expand-form? f)
+       (for-each handle (select-cond-expand-clause (cdr f) known-libs))]
+      [(define-library-form? f)
+       (register-library! f registry source-file known-libs)
+       (set! lib-order (cons (cadr f) lib-order))]
+      [(import-form? f)
+       ;; Top-level program import: validate names, then drop.
+       (for ([iset (cdr f)])
+         (define name (import-set->name iset))
+         (unless (library-known? name known-libs)
+           (error 'import "unknown library: ~a" name)))]
+      [else (set! program-forms (cons f program-forms))]))
+
+  (for-each handle exprs)
+
+  ;; Validate each library's own imports too (catches typos in deps).
+  (for ([(name l) (in-hash registry)])
+    (for ([iset (lib-imports l)])
+      (define dep (import-set->name iset))
+      (unless (library-known? dep known-libs)
+        (error 'import "library ~a imports unknown library: ~a" name dep))))
+
+  (define ordered (topo-sort-libraries registry (reverse lib-order)))
+  (append (append-map (lambda (name) (lib-body (hash-ref registry name))) ordered)
+          (reverse program-forms)))

--- a/languages/scheme/library.rkt
+++ b/languages/scheme/library.rkt
@@ -33,7 +33,7 @@
 
 (require "reader.rkt")
 
-(provide lower-libraries)
+(provide lower-libraries library-search-paths)
 
 ;; ---------------------------------------------------------------------------
 ;; Feature set and known standard libraries
@@ -352,20 +352,87 @@
   (reverse result))
 
 ;; ---------------------------------------------------------------------------
+;; Library search path: loading file-based libraries by name
+;; ---------------------------------------------------------------------------
+
+;; Extra root directories to search for library files, beyond the source
+;; file's own directory and the current directory. Set from the compiler
+;; CLI (-I / --lib-dir). A library named (foo bar) is sought as the file
+;; foo/bar.sld (then foo/bar.scm) under each root. Like static linking
+;; generally, a found library is compiled into the program, not shared.
+(define library-search-paths (make-parameter '()))
+
+(define (source-dir-or-cwd source-file)
+  (if source-file
+      (or (path-only source-file) (current-directory))
+      (current-directory)))
+
+;; Locate the file defining library NAME, or #f. (foo bar) -> foo/bar.<ext>.
+(define (find-library-file name source-file)
+  (define comps (map (lambda (c) (format "~a" c)) name))
+  (define roots (append (list (source-dir-or-cwd source-file))
+                        (library-search-paths)
+                        (list (current-directory))))
+  (for*/or ([root (in-list roots)]
+            [ext (in-list '(".sld" ".scm"))])
+    (define file-comps
+      (append (drop-right comps 1)
+              (list (string-append (last comps) ext))))
+    (define p (apply build-path root file-comps))
+    (and (file-exists? p) p)))
+
+;; Load and register the library NAME (and any sibling define-library forms
+;; in the same file) from the search path. Includes inside the file resolve
+;; relative to the file itself.
+(define (load-library-file! name registry in-file-names source-file index-box)
+  (define file (find-library-file name source-file))
+  (unless file
+    (error 'import "cannot find library ~s on the search path" name))
+  (define forms (read-all-exprs (file->string file) (path->string file)))
+  (define defs (filter define-library-form? forms))
+  (unless (findf (lambda (f) (equal? (cadr f) name)) defs)
+    (error 'import "file ~a does not define library ~s" file name))
+  (for ([f defs])
+    (unless (hash-has-key? registry (cadr f))
+      (register-library! f registry file
+                         (append in-file-names (hash-keys registry))
+                         (unbox index-box))
+      (set-box! index-box (add1 (unbox index-box))))))
+
+;; Iteratively load every imported library that is neither standard nor
+;; already registered, following transitive imports to a fixpoint. Each
+;; load adds at least the requested library, so this terminates.
+(define (resolve-file-libraries! registry program-imports in-file-names
+                                 source-file index-box)
+  (let loop ()
+    (define all-imports
+      (append program-imports (append-map lib-imports (hash-values registry))))
+    (define missing
+      (remove-duplicates
+       (for/list ([iset (in-list all-imports)]
+                  #:when (let ([d (import-base iset)])
+                           (and (not (standard-library? d))
+                                (not (hash-has-key? registry d)))))
+         (import-base iset))))
+    (unless (null? missing)
+      (for ([name (in-list missing)])
+        (load-library-file! name registry in-file-names source-file index-box))
+      (loop))))
+
+;; ---------------------------------------------------------------------------
 ;; Top-level lowering
 ;; ---------------------------------------------------------------------------
 
 (define (lower-libraries exprs [source-file #f])
-  ;; Shallow pre-scan of library names so (library X) cond-expand tests and
-  ;; import validation are independent of source order.
-  (define known-libs
+  ;; Shallow pre-scan of in-file library names so (library X) cond-expand
+  ;; tests and import validation are independent of source order.
+  (define in-file-names
     (for/list ([f exprs] #:when (define-library-form? f)) (cadr f)))
 
   (define registry (make-hash))
-  (define lib-order '())       ; registered names, definition order (reversed)
   (define program-forms '())   ; non-library top-level forms (reversed)
   (define program-imports '()) ; top-level import sets (reversed)
-  (define next-index 0)
+  (define index-box (box 0))   ; unique index source for mangling
 
   (define (handle f)
     (cond
@@ -375,11 +442,12 @@
        (for ([path (cdr f)])
          (for-each handle (read-included-exprs path source-file)))]
       [(cond-expand-form? f)
-       (for-each handle (select-cond-expand-clause (cdr f) known-libs))]
+       (for-each handle (select-cond-expand-clause (cdr f) in-file-names))]
       [(define-library-form? f)
-       (register-library! f registry source-file known-libs next-index)
-       (set! next-index (add1 next-index))
-       (set! lib-order (cons (cadr f) lib-order))]
+       (register-library! f registry source-file
+                          (append in-file-names (hash-keys registry))
+                          (unbox index-box))
+       (set-box! index-box (add1 (unbox index-box)))]
       [(import-form? f)
        (set! program-imports (append (reverse (cdr f)) program-imports))]
       [else (set! program-forms (cons f program-forms))]))
@@ -388,7 +456,17 @@
   (set! program-imports (reverse program-imports))
   (set! program-forms (reverse program-forms))
 
-  ;; Validate each library's own imports (catches typos in deps).
+  ;; Load any imported library not defined in this file from the search path.
+  (resolve-file-libraries! registry program-imports in-file-names
+                           source-file index-box)
+
+  ;; Validate every import now that in-file and file-loaded libraries are
+  ;; all registered.
+  (define known-libs (append in-file-names (hash-keys registry)))
+  (for ([iset (in-list program-imports)])
+    (define dep (import-base iset))
+    (unless (library-known? dep known-libs)
+      (error 'import "unknown library: ~a" dep)))
   (for ([(name l) (in-hash registry)])
     (for ([iset (lib-imports l)])
       (define dep (import-base iset))
@@ -412,7 +490,10 @@
     (hash-remove! program-subst n))
 
   ;; Emit mangled library bodies (dependency order) then mangled program.
-  (define ordered (topo-sort-libraries registry (reverse lib-order)))
+  ;; Seed the sort with all registered libraries (in-file + file-loaded) in
+  ;; index order for a deterministic, dependency-correct emission.
+  (define seed (map lib-name (sort (hash-values registry) < #:key lib-index)))
+  (define ordered (topo-sort-libraries registry seed))
   (define lib-out
     (append-map (lambda (name)
                   (define l (hash-ref registry name))

--- a/languages/scheme/main.rkt
+++ b/languages/scheme/main.rkt
@@ -5,6 +5,7 @@
 
 (require racket/runtime-path
          "reader.rkt"
+         "library.rkt"   ; R7RS define-library / import / cond-expand lowering
          "expander.rkt"  ; Macro expansion
          "rewriter.rkt"
          "letrec-lifting.rkt"  ; Lift single self-recursive letrec to top level
@@ -65,7 +66,9 @@
 ;; source-file: optional path for resolving include directives.
 (define (compile-string source-code [source-file #f])
   (opt-stats-reset!)
-  (let* ([user-exprs (read-all-exprs source-code source-file)]
+  (let* ([user-exprs (lower-libraries
+                       (read-all-exprs source-code source-file)
+                       source-file)]
          ;; Prepend the runtime-library prelude. Dead-define elimination
          ;; later in the pipeline drops anything the user doesn't use.
          [exprs (append prelude-exprs user-exprs)]

--- a/languages/scheme/main.rkt
+++ b/languages/scheme/main.rkt
@@ -197,6 +197,10 @@
    [("--batch") manifest
                 "Compile every SRC[<tab>DEST] line in MANIFEST in one process"
                 (set! batch-file manifest)]
+   #:multi
+   [("-I" "--lib-dir") dir
+                "Add DIR to the R7RS library search path (repeatable)"
+                (library-search-paths (append (library-search-paths) (list dir)))]
    #:args sources
    (cond
      [batch-file

--- a/languages/scheme/reader.rkt
+++ b/languages/scheme/reader.rkt
@@ -9,6 +9,7 @@
 
 (provide read-all-exprs
          read-expr
+         read-included-exprs
          include-search-paths)
 
 ;; Compiler-side search path used as a fallback when an (include "X")
@@ -51,11 +52,17 @@
 ;; pattern/template lists that look like expressions but are matched, not
 ;; evaluated. (Quasiquote with embedded unquote-include is a corner case
 ;; we don't attempt to support.)
+;; define-library and cond-expand are skipped here so the library pass
+;; (library.rkt) owns include resolution inside them: cond-expand must
+;; pick a clause before its includes are read (a blind splice would pull
+;; files from dead branches), and a library's includes are declarations
+;; that the library pass reads via read-included-exprs.
 (define (skip-include-walk? head)
   (and (symbol? head)
        (memq head '(quote quasiquote
                           define-syntax let-syntax letrec-syntax
-                          syntax-rules))))
+                          syntax-rules
+                          define-library cond-expand))))
 
 ;; Walk the children of a form via cons-based traversal so the walker
 ;; copes with improper lists (e.g. the (FUNC . REST) formals in
@@ -131,6 +138,19 @@
                                                     resolved-path
                                                     new-included)])
       included-exprs)))
+
+;; Read and return the expressions of an included file, resolving the
+;; path exactly as the reader's own (include ...) handling does (source-
+;; relative first, then the configured search paths). Used by the library
+;; pass for include / include-ci / include-library-declarations, which
+;; are skipped by the in-reader include walker. Nested (include ...)
+;; forms in the file are expanded by read-all-exprs as usual.
+(define (read-included-exprs include-path source-file)
+  (let ([resolved (resolve-include-path include-path source-file)])
+    (unless (file-exists? resolved)
+      (error 'include "File not found: ~a (resolved to: ~a)"
+             include-path resolved))
+    (read-all-exprs (file->string resolved) resolved)))
 
 ;; Resolve include path. Absolute paths are used verbatim. Relative paths
 ;; resolve against the including file's directory first; if that file

--- a/tests/unit-tests/r7rs/mathx.sld
+++ b/tests/unit-tests/r7rs/mathx.sld
@@ -1,0 +1,8 @@
+;;; Library file loaded by name via the R7RS library search path.
+;;; Imported as (mathx) by test-library-search.scm in the same directory.
+(define-library (mathx)
+  (import (scheme base))
+  (export cube halve)
+  (begin
+    (define (cube x) (* x x x))
+    (define (halve x) (quotient x 2))))

--- a/tests/unit-tests/r7rs/test-library-basic.scm
+++ b/tests/unit-tests/r7rs/test-library-basic.scm
@@ -1,0 +1,47 @@
+;;; VeloxVM Unit Tests - R7RS library system
+;;; Exercises define-library / import / export lowering. This is a
+;;; flat, permissive lowering (see doc/r7rs-library-system-design.md):
+;;; library bodies are spliced into the single namespace, standard
+;;; imports are no-ops, and imports validate the name but do not hide
+;;; un-imported bindings.
+
+(include "../unit-test-framework.scm")
+
+;; A standard-import library: (scheme base) resolves to existing
+;; primitives/prelude, so importing it is a no-op that must still compile.
+(define-library (test math)
+  (import (scheme base))
+  (export square cube)
+  (begin
+    (define (square x) (* x x))
+    (define (cube x) (* x x x))))
+
+;; Cross-library dependency: chain-b imports chain-a. Emission order is
+;; topologically sorted so chain-a precedes chain-b.
+(define-library (test chain-a)
+  (export inc)
+  (begin (define (inc x) (+ x 1))))
+
+(define-library (test chain-b)
+  (import (test chain-a))
+  (export add2)
+  (begin (define (add2 x) (inc (inc x)))))
+
+;; Two exports; we import with (only ...) to check permissive resolution.
+(define-library (test pair-exports)
+  (export a b)
+  (begin (define a 1) (define b 2)))
+
+(import (test math))
+(import (test chain-b))
+(import (only (test pair-exports) a))
+
+(test-suite "R7RS library system")
+
+(assert-equal 36 (square 6) "imported procedure (square)")
+(assert-equal 27 (cube 3)   "imported procedure (cube)")
+(assert-equal 12 (add2 10)  "cross-library import (chain-b uses chain-a)")
+(assert-equal 1  a          "(only ...) brings in the selected name")
+(assert-equal 2  b          "permissive: un-selected export still visible")
+
+(test-summary)

--- a/tests/unit-tests/r7rs/test-library-basic.scm
+++ b/tests/unit-tests/r7rs/test-library-basic.scm
@@ -1,9 +1,8 @@
-;;; VeloxVM Unit Tests - R7RS library system
-;;; Exercises define-library / import / export lowering. This is a
-;;; flat, permissive lowering (see doc/r7rs-library-system-design.md):
-;;; library bodies are spliced into the single namespace, standard
-;;; imports are no-ops, and imports validate the name but do not hide
-;;; un-imported bindings.
+;;; VeloxVM Unit Tests - R7RS library system (basic)
+;;; Exercises define-library / import / export lowering: library bodies
+;;; lower into the program, standard imports are no-ops, and a user
+;;; library's exports become available to importers. Isolation and import
+;;; sets are covered in test-library-isolation.scm.
 
 (include "../unit-test-framework.scm")
 
@@ -27,21 +26,21 @@
   (export add2)
   (begin (define (add2 x) (inc (inc x)))))
 
-;; Two exports; we import with (only ...) to check permissive resolution.
+;; Two exports, brought in with a plain import.
 (define-library (test pair-exports)
   (export a b)
   (begin (define a 1) (define b 2)))
 
 (import (test math))
 (import (test chain-b))
-(import (only (test pair-exports) a))
+(import (test pair-exports))
 
-(test-suite "R7RS library system")
+(test-suite "R7RS library system (basic)")
 
 (assert-equal 36 (square 6) "imported procedure (square)")
 (assert-equal 27 (cube 3)   "imported procedure (cube)")
 (assert-equal 12 (add2 10)  "cross-library import (chain-b uses chain-a)")
-(assert-equal 1  a          "(only ...) brings in the selected name")
-(assert-equal 2  b          "permissive: un-selected export still visible")
+(assert-equal 1  a          "plain import brings in exported value a")
+(assert-equal 2  b          "plain import brings in exported value b")
 
 (test-summary)

--- a/tests/unit-tests/r7rs/test-library-cond-expand.scm
+++ b/tests/unit-tests/r7rs/test-library-cond-expand.scm
@@ -1,0 +1,42 @@
+;;; VeloxVM Unit Tests - R7RS cond-expand
+;;; cond-expand is resolved at compile time against the static feature
+;;; set in languages/scheme/library.rkt (kept in sync with the runtime
+;;; (features) procedure in runtime/r7rs-features.scm) plus the set of
+;;; known libraries.
+
+(include "../unit-test-framework.scm")
+
+(cond-expand
+  (veloxvm (define ce-feature "velox"))
+  (else    (define ce-feature "other")))
+
+(cond-expand
+  ((library (scheme base)) (define ce-lib "has-base"))
+  (else                    (define ce-lib "no-base")))
+
+(cond-expand
+  (nonexistent-feature (define ce-fallback "wrong"))
+  (else                (define ce-fallback "fallback")))
+
+(cond-expand
+  ((and veloxvm r5rs) (define ce-and "both"))
+  (else               (define ce-and "not-both")))
+
+(cond-expand
+  ((or nonexistent veloxvm) (define ce-or "or-ok"))
+  (else                     (define ce-or "or-fail")))
+
+(cond-expand
+  ((not nonexistent) (define ce-not "not-ok"))
+  (else              (define ce-not "not-fail")))
+
+(test-suite "R7RS cond-expand")
+
+(assert-equal "velox"    ce-feature  "feature id selects matching clause")
+(assert-equal "has-base" ce-lib      "(library ...) true for a standard library")
+(assert-equal "fallback" ce-fallback "else taken when no requirement matches")
+(assert-equal "both"     ce-and      "(and ...) requirement")
+(assert-equal "or-ok"    ce-or       "(or ...) requirement")
+(assert-equal "not-ok"   ce-not      "(not ...) requirement")
+
+(test-summary)

--- a/tests/unit-tests/r7rs/test-library-isolation.scm
+++ b/tests/unit-tests/r7rs/test-library-isolation.scm
@@ -1,0 +1,55 @@
+;;; VeloxVM Unit Tests - R7RS library isolation + import sets
+;;; Mangling renames each library's top-level definitions to unique names,
+;;; so same-named internal bindings in different libraries no longer
+;;; collide, and the only/except/prefix/rename import sets resolve over a
+;;; user library's exports. See doc/r7rs-library-system-design.md.
+
+(include "../unit-test-framework.scm")
+
+;; --- Isolation: two libraries with an identically named private helper.
+;; Under a flat namespace these would collide (the second helper would win
+;; for both); mangling keeps them distinct.
+(define-library (iso-a)
+  (export a-val)
+  (begin
+    (define (helper) 100)
+    (define (a-val) (helper))))
+
+(define-library (iso-b)
+  (export b-val)
+  (begin
+    (define (helper) 200)
+    (define (b-val) (helper))))
+
+;; --- Import sets over a user library.
+(define-library (sets)
+  (export one two three)
+  (begin (define one 1) (define two 2) (define three 3)))
+
+;; --- Quote / quasiquote protection: quoted occurrences of a library's own
+;; (mangled) names must not be rewritten.
+(define-library (q)
+  (export valsym qqbuild val)
+  (begin
+    (define (val) 99)
+    (define (valsym) 'val)            ; 'val is data; stays 'val, not 'val$Lk
+    (define (qqbuild) `(val ,(val))))) ; literal val preserved; ,(val) substituted
+
+(import (iso-a))
+(import (iso-b))
+(import (only (sets) one))
+(import (rename (sets) (three iii)))
+(import (prefix (sets) s:))
+(import (q))
+
+(test-suite "R7RS library isolation + import sets")
+
+(assert-equal 100 (a-val) "private helper isolated (iso-a)")
+(assert-equal 200 (b-val) "private helper isolated (iso-b)")
+(assert-equal 1   one     "(only ...) imports the named binding")
+(assert-equal 3   iii     "(rename ...) imports under the new name")
+(assert-equal 2   s:two   "(prefix ...) imports under the prefixed name")
+(assert-equal 'val (valsym)    "quoted datum not mangled")
+(assert-equal '(val 99) (qqbuild) "quasiquote literal preserved, unquote substituted")
+
+(test-summary)

--- a/tests/unit-tests/r7rs/test-library-macros.scm
+++ b/tests/unit-tests/r7rs/test-library-macros.scm
@@ -1,0 +1,49 @@
+;;; VeloxVM Unit Tests - R7RS library macros
+;;; A library's define-syntax names are mangled like its value
+;;; definitions, so macros are isolated per library and participate in
+;;; export / import sets, and a macro template's references to the
+;;; library's own (possibly non-exported) bindings are rewritten
+;;; consistently. See doc/r7rs-library-system-design.md.
+
+(include "../unit-test-framework.scm")
+
+;; Exported macro that expands to a use of a NON-exported helper.
+(define-library (mac-a)
+  (export quad)
+  (begin
+    (define (dbl x) (* x 2))
+    (define-syntax quad (syntax-rules () ((_ e) (dbl (dbl e)))))))
+
+;; Two libraries with identical macro and helper names: must stay isolated.
+(define-library (mac-b)
+  (export bump)
+  (begin
+    (define (step x) (+ x 1))
+    (define-syntax bump (syntax-rules () ((_ e) (step e))))))
+
+(define-library (mac-c)
+  (export bump)
+  (begin
+    (define (step x) (+ x 10))
+    (define-syntax bump (syntax-rules () ((_ e) (step e))))))
+
+;; Macro that expands to a use of a library value binding.
+(define-library (mac-d)
+  (export with-base)
+  (begin
+    (define base 1000)
+    (define-syntax with-base (syntax-rules () ((_ e) (+ base e))))))
+
+(import (mac-a))
+(import (rename (mac-b) (bump bump1)))
+(import (prefix (mac-c) c:))
+(import (mac-d))
+
+(test-suite "R7RS library macros")
+
+(assert-equal 40   (quad 10)     "exported macro over a non-exported helper")
+(assert-equal 6    (bump1 5)     "macro imported via rename uses its own helper")
+(assert-equal 15   (c:bump 5)    "macro imported via prefix; isolated from mac-b")
+(assert-equal 1005 (with-base 5) "macro expands to use of a library binding")
+
+(test-summary)

--- a/tests/unit-tests/r7rs/test-library-search.scm
+++ b/tests/unit-tests/r7rs/test-library-search.scm
@@ -1,0 +1,16 @@
+;;; VeloxVM Unit Tests - R7RS library search path
+;;; (import (mathx)) is not defined in this file; it is loaded from
+;;; mathx.sld in the same directory via the library search path (the
+;;; source file's own directory is searched first). The loaded library is
+;;; mangled and compiled into the program like an in-file library.
+
+(include "../unit-test-framework.scm")
+
+(import (mathx))
+
+(test-suite "R7RS library search path")
+
+(assert-equal 27 (cube 3)  "procedure from a file-loaded library")
+(assert-equal 5  (halve 10) "second export from a file-loaded library")
+
+(test-summary)


### PR DESCRIPTION
Adds an R7RS-small library system to the Scheme front-end as a source-to-source pass (`languages/scheme/library.rkt`, run from `compile-string` after the reader). No VM-core or bytecode changes.

- **`define-library` / `import` / `export` / `cond-expand`** lowered into the existing flat namespace; standard imports (`(scheme base)`, …) are no-ops, unknown libraries error.
- **Isolation by name-mangling** — each library's top-level definitions are renamed to unique symbols, so same-named internals across libraries don't collide.
- **Import sets** `only` / `except` / `prefix` / `rename` and `export` rename for user libraries, with conflicting-import detection.
- **Library search path** — an imported library not defined in the file is loaded from `foo/bar.sld` (or `.scm`) under the source dir, `-I`/`--lib-dir` dirs, then the cwd; transitive.
- **Macros** participate too: a library's `define-syntax` is isolated and importable like values, and macro templates can reference the library's own (non-exported) bindings.

Not yet supported: import sets on *standard* libraries and strict mode (both documented).